### PR TITLE
Adding getUnitsAround a rectangular area in PhysicalGameState

### DIFF
--- a/src/rts/PhysicalGameState.java
+++ b/src/rts/PhysicalGameState.java
@@ -273,12 +273,11 @@ public class PhysicalGameState {
     }
     
     /**
-     * Returns units within a rectangular area starting in the provided x and y
-     * coordinates, with the specified width and height
-     * @param x 
-     * @param y 
-     * @param width 
-     * @param height  
+     * Returns units within a rectangular area 
+     * @param x top left coordinate of the rectangle
+     * @param y top left coordinate of the square 
+     * @param width rectangle width
+     * @param height rectangle height
      * @return
      */
     public Collection<Unit> getUnitsAround(int x, int y, int width, int height) {

--- a/src/rts/PhysicalGameState.java
+++ b/src/rts/PhysicalGameState.java
@@ -263,13 +263,8 @@ public class PhysicalGameState {
      * @return
      */
     public Collection<Unit> getUnitsAround(int x, int y, int squareRange) {
-        List<Unit> closeUnits = new LinkedList<Unit>();
-        for (Unit u : units) {
-            if ((Math.abs(u.getX() - x) <= squareRange && Math.abs(u.getY() - y) <= squareRange)) {
-                closeUnits.add(u);
-            }
-        }
-        return closeUnits;
+        // returns the units around a rectangle with same width and height
+    	return getUnitsAround(x, y, squareRange, squareRange);
     }
     
     /**

--- a/src/rts/PhysicalGameState.java
+++ b/src/rts/PhysicalGameState.java
@@ -257,8 +257,8 @@ public class PhysicalGameState {
     /**
      * Returns the units within a squared area
      *
-     * @param x bottom left coordinate of the square
-     * @param y bottom left coordinate of the square
+     * @param x top left coordinate of the square
+     * @param y top left coordinate of the square
      * @param squareRange square size
      * @return
      */
@@ -271,6 +271,27 @@ public class PhysicalGameState {
         }
         return closeUnits;
     }
+    
+    /**
+     * Returns units within a rectangular area starting in the provided x and y
+     * coordinates, with the specified width and height
+     * @param x 
+     * @param y 
+     * @param width 
+     * @param height  
+     * @return
+     */
+    public Collection<Unit> getUnitsAround(int x, int y, int width, int height) {
+        List<Unit> closeUnits = new LinkedList<Unit>();
+        for (Unit u : units) {
+            if ((Math.abs(u.getX() - x) <= width && Math.abs(u.getY() - y) <= height)) {
+                closeUnits.add(u);
+            }
+        }
+        return closeUnits;
+    }
+    
+    
 
     /**
      * Returns the winner of the game, given the unit counts or -1 if the game


### PR DESCRIPTION
Added a new method to get the units around a rectangular area (the existing one, which was kept, is for squared area).

I also corrected the existing documentation, where x and y were said to be the bottom left square coordinate, but they're the top left. microRTS's coordinate system follows the matrix orientation, right?