### PR TITLE
Encapsulating creation and reading to/from xml file

### DIFF
--- a/src/rts/GameState.java
+++ b/src/rts/GameState.java
@@ -4,9 +4,18 @@ import com.eclipsesource.json.Json;
 import com.eclipsesource.json.JsonArray;
 import com.eclipsesource.json.JsonObject;
 import com.eclipsesource.json.JsonValue;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
 import java.io.Writer;
 import java.util.*;
+
+import org.jdom.Document;
 import org.jdom.Element;
+import org.jdom.JDOMException;
+import org.jdom.input.SAXBuilder;
+
 import rts.units.Unit;
 import rts.units.UnitType;
 import rts.units.UnitTypeTable;
@@ -726,7 +735,7 @@ public class GameState {
 
     
     /**
-     * Writes a XML representation of this state
+     * Writes a XML representation of this state into a XMLWriter
      * @param w
      */
     public void toxml(XMLWriter w) {
@@ -743,7 +752,22 @@ public class GameState {
         w.tag("/" + this.getClass().getName());
     }
     
-
+    /**
+     * Dumps this state to a XML file.
+     * It can be reconstructed later (e.g. with {@link #fromXML(String, UnitTypeTable)}
+     * @param path
+     */
+    public void toxml(String path) {
+    	try {
+			XMLWriter dumper = new XMLWriter(new FileWriter(path));
+			this.toxml(dumper);
+			dumper.close();
+		} catch (IOException e) {
+			System.err.println("Error while writing state to: " + path);
+			e.printStackTrace();
+		}
+    }
+    
     /**
      * Writes a JSON representation of this state
      * @param w
@@ -768,7 +792,7 @@ public class GameState {
     }
     
     /**
-     * Constructs a GameState from XML
+     * Constructs a GameState from a XML Element
      * @param e
      * @param utt
      * @return
@@ -790,6 +814,33 @@ public class GameState {
         }
         
         return gs;
+    }
+    
+    /**
+     * Returns the GameState previously dumped (e.g. with {@link #toxml(String)} from the specified file.
+     * @param utt
+     * @param path
+     * @return
+     */
+    public static GameState fromXML(String path, UnitTypeTable utt) {
+    	SAXBuilder builder = new SAXBuilder();
+		File xmlFile = new File(path);
+		Document document = null;
+		GameState reconstructed = null;
+		try {
+			document = (Document) builder.build(xmlFile);
+		} catch (JDOMException | IOException e) {
+			System.err.println("Error while opening file: '" + path + "'. Returning null.");
+			e.printStackTrace();
+		}
+		try {
+			reconstructed = GameState.fromXML(document.getRootElement(), utt);
+		} catch (Exception e) {
+			System.err.println("ERror while reconstructing the state from the XML element. Returning null.");
+			e.printStackTrace();
+		}
+		
+		return reconstructed;
     }
     
     /**


### PR DESCRIPTION
The additions make it easier to dump and load a GameState to/from a xml file, as the user does not need to create the XMLWriter or Element. The added methods just receive the path to write to or read from and do the job under the hood.