### PR TITLE
Adding support to write zipped trace files

### DIFF
--- a/src/rts/Trace.java
+++ b/src/rts/Trace.java
@@ -1,7 +1,15 @@
 package rts;
 
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.FileWriter;
+import java.io.IOException;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
 import org.jdom.Element;
 import rts.units.Unit;
 import rts.units.UnitTypeTable;
@@ -87,6 +95,52 @@ public class Trace {
         }
         w.tag("/entries");
         w.tag("/" + this.getClass().getName());
+    }
+    
+    /**
+     * Dumps this trace to the XML file specified on path
+     * It can be reconstructed later (e.g. with {@link #fromXML(String, UnitTypeTable)}
+     * @param path
+     */
+    public void toxml(String path) {
+    	try {
+			XMLWriter dumper = new XMLWriter(new FileWriter(path));
+			this.toxml(dumper);
+			dumper.close();
+		} catch (IOException e) {
+			System.err.println("Error while writing trace to: " + path);
+			e.printStackTrace();
+		}
+    }
+    
+    public void toZip(String path) {    	
+    	//ensures path will end with a .zip
+    	if(!path.endsWith(".zip")) {
+    		path += ".zip";
+    	}
+    	
+    	File f = new File(path);
+    	ZipOutputStream out;
+		try {
+			out = new ZipOutputStream(new FileOutputStream(f));
+			ZipEntry e = new ZipEntry("foo.txt");
+	    	out.putNextEntry(e);
+
+	    	XMLWriter dumper = new XMLWriter(new FileWriter(path));
+			this.toxml(dumper);
+	    	byte[] data = dumper.toString().getBytes();
+	    	out.write(data, 0, data.length);
+	    	out.closeEntry();
+
+	    	out.close();
+		} catch (FileNotFoundException e1) {
+			System.err.println("File not found: " + path);
+			e1.printStackTrace();
+		} catch (IOException e1) {
+			System.err.println("Error while writing to " + path);
+			e1.printStackTrace();
+		}
+    	
     }
 
     /**

--- a/src/rts/Trace.java
+++ b/src/rts/Trace.java
@@ -6,6 +6,7 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.io.StringWriter;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.zip.ZipEntry;
@@ -117,26 +118,34 @@ public class Trace {
 		}
     }
     
-    public void toZip(String path) {    	
-    	//ensures path will end with a .zip
-    	if(!path.endsWith(".zip")) {
-    		path += ".zip";
+    public void toZip(String path) {
+    	String zipPath;
+    	//zipPath must end with .zip and path with .xml
+    	if(path.endsWith(".zip")) {
+    		zipPath = path;
+    		path.replaceFirst("[.][^.]+$", ".xml"); // replaces .zip by .xml
+    	}
+    	else {
+    		zipPath = path + ".zip";    		
     	}
     	
     	File f = new File(path);
     	ZipOutputStream out;
 		try {
 			out = new ZipOutputStream(new FileOutputStream(f));
-			ZipEntry e = new ZipEntry("foo.txt");
+			ZipEntry e = new ZipEntry(f.getName());
 	    	out.putNextEntry(e);
 
-	    	XMLWriter dumper = new XMLWriter(new FileWriter(path));
+	    	StringWriter xmlStringContainer = new StringWriter();
+	    	XMLWriter dumper = new XMLWriter(xmlStringContainer);
+	    	//XMLWriter dumper = new XMLWriter(new FileWriter(path));
 			this.toxml(dumper);
-	    	byte[] data = dumper.toString().getBytes();
+			
+	    	byte[] data = xmlStringContainer.toString().getBytes();
 	    	out.write(data, 0, data.length);
 	    	out.closeEntry();
-
 	    	out.close();
+	    	
 		} catch (FileNotFoundException e1) {
 			System.err.println("File not found: " + path);
 			e1.printStackTrace();

--- a/src/rts/Trace.java
+++ b/src/rts/Trace.java
@@ -1,6 +1,7 @@
 package rts;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.FileWriter;
@@ -8,9 +9,12 @@ import java.io.IOException;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
 import java.util.zip.ZipOutputStream;
 
 import org.jdom.Element;
+import org.jdom.input.SAXBuilder;
+
 import rts.units.Unit;
 import rts.units.UnitTypeTable;
 import util.Pair;
@@ -141,6 +145,12 @@ public class Trace {
 			e1.printStackTrace();
 		}
     	
+    }
+    
+    public static Trace fromZip(String path) throws Exception {
+    	 ZipInputStream zis = new ZipInputStream(new FileInputStream(path));
+		 zis.getNextEntry();
+		 return new Trace(new SAXBuilder().build(zis).getRootElement());
     }
 
     /**

--- a/src/tests/trace/TraceGenerationTest.java
+++ b/src/tests/trace/TraceGenerationTest.java
@@ -2,7 +2,7 @@
  * To change this template, choose Tools | Templates
  * and open the template in the editor.
  */
-package tests;
+package tests.trace;
 
 import ai.core.AI;
 import ai.abstraction.WorkerRush;
@@ -12,6 +12,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import rts.*;
 import rts.units.UnitTypeTable;
+import tests.MapGenerator;
 import util.XMLWriter;
 
 /**

--- a/src/tests/trace/TraceVisualizationTest.java
+++ b/src/tests/trace/TraceVisualizationTest.java
@@ -2,7 +2,7 @@
  * To change this template, choose Tools | Templates
  * and open the template in the editor.
  */
-package tests;
+package tests.trace;
 
 import gui.TraceVisualizer;
 

--- a/src/tests/trace/ZipTraceGenerationTest.java
+++ b/src/tests/trace/ZipTraceGenerationTest.java
@@ -23,7 +23,7 @@ public class ZipTraceGenerationTest {
     public static void main(String args[]) throws IOException, Exception {
         UnitTypeTable utt = new UnitTypeTable();
         MapGenerator mg = new MapGenerator(utt);
-        PhysicalGameState pgs = mg.complexBasesWorkers12x12();// basesWorkers8x8Obstacle();
+        PhysicalGameState pgs = mg.basesWorkers8x8Obstacle();
         GameState gs = new GameState(pgs, utt);
         int MAXCYCLES = 5000;
         boolean gameover = false;

--- a/src/tests/trace/ZipTraceGenerationTest.java
+++ b/src/tests/trace/ZipTraceGenerationTest.java
@@ -1,0 +1,65 @@
+/*
+ * To change this template, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package tests.trace;
+
+import ai.core.AI;
+import ai.abstraction.WorkerRush;
+import ai.*;
+import ai.abstraction.pathfinding.BFSPathFinding;
+import java.io.FileWriter;
+import java.io.IOException;
+import rts.*;
+import rts.units.UnitTypeTable;
+import tests.MapGenerator;
+import util.XMLWriter;
+
+/**
+ *
+ * @author santi
+ */
+public class ZipTraceGenerationTest {
+    public static void main(String args[]) throws IOException, Exception {
+        UnitTypeTable utt = new UnitTypeTable();
+        MapGenerator mg = new MapGenerator(utt);
+        PhysicalGameState pgs = mg.complexBasesWorkers12x12();// basesWorkers8x8Obstacle();
+        GameState gs = new GameState(pgs, utt);
+        int MAXCYCLES = 5000;
+        boolean gameover = false;
+        
+        AI ai1 = new RandomBiasedAI();
+        AI ai2 = new WorkerRush(utt, new BFSPathFinding());
+        
+        Trace trace = new Trace(utt);
+        TraceEntry te = new TraceEntry(gs.getPhysicalGameState().clone(),gs.getTime());
+        trace.addEntry(te);
+        
+        do{
+            PlayerAction pa1 = ai1.getAction(0, gs);
+            PlayerAction pa2 = ai2.getAction(1, gs);
+            
+            if (!pa1.isEmpty() || !pa2.isEmpty()) {
+                te = new TraceEntry(gs.getPhysicalGameState().clone(),gs.getTime());
+                te.addPlayerAction(pa1.clone());
+                te.addPlayerAction(pa2.clone());
+                trace.addEntry(te);
+            }
+
+            gs.issueSafe(pa1);
+            gs.issueSafe(pa2);
+
+            // simulate:
+            gameover = gs.cycle();
+        }while(!gameover && gs.getTime()<MAXCYCLES);
+        ai1.gameOver(gs.winner());
+        ai2.gameOver(gs.winner());
+        
+        te = new TraceEntry(gs.getPhysicalGameState().clone(), gs.getTime());
+        trace.addEntry(te);
+        
+        trace.toZip("trace.zip");
+        
+        System.out.println("Done.");
+    }    
+}

--- a/src/tests/trace/ZipTraceVisualizationTest.java
+++ b/src/tests/trace/ZipTraceVisualizationTest.java
@@ -1,0 +1,34 @@
+/*
+ * To change this template, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package tests.trace;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.zip.ZipInputStream;
+
+import javax.swing.JFrame;
+
+import org.jdom.JDOMException;
+import org.jdom.input.SAXBuilder;
+
+import gui.TraceVisualizer;
+import rts.Trace;
+
+/**
+ *
+ * @author santi
+ */
+public class ZipTraceVisualizationTest {
+
+  public static void main(String []args) throws JDOMException, IOException, Exception {
+	  
+	  Trace t = Trace.fromZip(args[0]);
+	  
+	  JFrame tv = TraceVisualizer.newWindow("Demo", 800, 600, t, 1);
+	  tv.show();
+          
+      System.out.println("Trace winner: " + t.winner());
+  }    
+}


### PR DESCRIPTION
Now we just need to call Trace.toZip(path) to create a zipped trace file (much smaller than pure xml). To load a zipped trace file, we just need to call Trace.fromZip. 

Also, moved the trace generation and visualization tests to a new package under tests and added the ones to test the zipped version. All tests passed :).