### PR TITLE
Add a unit type attribute check in the harvest action

### DIFF
--- a/src/rts/UnitAction.java
+++ b/src/rts/UnitAction.java
@@ -395,7 +395,7 @@ public class UnitAction {
                         maybeAResource = pgs.getUnitAt(u.getX() - 1, u.getY());
                         break;
                 }
-                if (maybeAResource != null && u.getType().canHarvest && u.getResources() == 0) {
+                if (maybeAResource != null && maybeAResource.getType().isResource && u.getType().canHarvest && u.getResources() == 0) {
                     //indeed it is a resource, harvest from it
                     maybeAResource.setResources(maybeAResource.getResources() - u.getHarvestAmount());
                     if (maybeAResource.getResources() <= 0) {


### PR DESCRIPTION
The unit `maybeAResource` is never checked for being really a resource, whereas, the harvesting unit is checked by `canHarvest`. This commit adds a check to see if this unit is a resource, by means of `isResource`.