### PR TITLE
Automated testing of source files using Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: java
+jdk:
+  - oraclejdk8
+  - oraclejdk9
+  - oraclejdk10
+  - oraclejdk11
+  - oraclejdk12
+  - openjdk8
+  - openjdk9
+  - openjdk10
+  - openjdk11
+  - openjdk12
+  - openjdk13
+
+script: javac -cp "lib/*:src" -d bin src/rts/MicroRTS.java
+
+# java -cp "lib/*:bin" rts.MicroRTS

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,8 @@
 language: java
 jdk:
-  - oraclejdk8
   - oraclejdk9
-  - oraclejdk10
   - oraclejdk11
   - oraclejdk12
-  - openjdk8
   - openjdk9
   - openjdk10
   - openjdk11

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,4 @@ jdk:
   - openjdk12
   - openjdk13
 
-script: javac -cp "lib/*:src" -d bin src/rts/MicroRTS.java
-
-# java -cp "lib/*:bin" rts.MicroRTS
+script: javac -cp "lib/*" -d bin $(find . -name "*.java")


### PR DESCRIPTION
This PR adds the necessary configuration to test the build process of microRTS under multiple versions of Java using the Travis CI service. This is done by listing the desired Java versions as well as the commands used to compile the source code in a `.travis.yml` file.

No code has been changed and no dependencies were added to the project.

Here are the results of the [automated tests](https://travis-ci.org/douglasrizzo/microrts/). This service provides a badge verifying that the project has built successfully. The badge can be added to the README, [like this](https://github.com/tensorflow/tensorflow#continuous-build-status).

In the future, other tests can be automated, for example, those contained in the `tests` package, if a script to run them is added to `.travis.yml`.