### PR TITLE
Added instructions to build microRTS through the terminal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 /bin/
 /.classpath
 /.project
-/.idea

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /bin/
 /.classpath
 /.project
+/.idea

--- a/README.md
+++ b/README.md
@@ -14,30 +14,24 @@ To cite microRTS, please cite this paper:
 
 Santiago Ontañón (2013) The Combinatorial Multi-Armed Bandit Problem and its Application to Real-Time Strategy Games, In AIIDE 2013. pp. 58 - 64.
 
-## Building
-Building using CLI
+## Instructions to build and run
 
-```bash
-javac -cp "lib/*:src" -d bin src/rts/MicroRTS.java
+To build and run microRTS using the Linux os Mac OS command line, run the following commands in the root folder of the project:
+
+```shell
+javac -cp "lib/*:src" -d bin src/rts/MicroRTS.java # to build
+java -cp "lib/*:bin" rts.MicroRTS # to run
 ```
 
-or in Windows
-```bash
-javac -cp "lib/*;src" -d bin src/rts/MicroRTS.java
+Or in Windows:
+
+```shell
+javac -cp "lib/*;src" -d bin src/rts/MicroRTS.java # to build
+java -cp "lib/*;bin" rts.MicroRTS # to run
 ```
 
-## Running
-Running in CLI
+If you want to run other classes that have a `main` method (such as `gui/frontend/FrontEnd.java`), change the build and run commands accordingly.
 
-```bash
-java -cp "lib/*:bin" rts.MicroRTS
-```
-
-or in Windows
-```bash
-java -cp "lib/*;bin" rts.MicroRTS
-```
-
-## Instructions:
+## Instructions
 
 ![instructions image](https://raw.githubusercontent.com/santiontanon/microrts/master/help.png)

--- a/README.md
+++ b/README.md
@@ -14,6 +14,30 @@ To cite microRTS, please cite this paper:
 
 Santiago Ontañón (2013) The Combinatorial Multi-Armed Bandit Problem and its Application to Real-Time Strategy Games, In AIIDE 2013. pp. 58 - 64.
 
+## Building
+Building using CLI
+
+```bash
+javac -cp "lib/*:src" -d bin src/rts/MicroRTS.java
+```
+
+or in Windows
+```bash
+javac -cp "lib/*;src" -d bin src/rts/MicroRTS.java
+```
+
+## Running
+Running in CLI
+
+```bash
+java -cp "lib/*:bin" rts.MicroRTS
+```
+
+or in Windows
+```bash
+java -cp "lib/*;bin" rts.MicroRTS
+```
+
 ## Instructions:
 
 ![instructions image](https://raw.githubusercontent.com/santiontanon/microrts/master/help.png)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ microRTS is deterministic and real-time (i.e. players can issue actions simultan
 
 microRTS was developed by [Santiago Ontañón](https://sites.google.com/site/santiagoontanonvillar/Home). 
 
-For a video of how microRTS looks like when a human plays, see a [youtube video](https://www.youtube.com/watch?v=ZsKKAoiD7B0)
+For a video of how microRTS looks like when a human plays, see a [YouTube video](https://www.youtube.com/watch?v=ZsKKAoiD7B0)
 
 If you are interested in testing your algorithms against other people's, **there is an annual microRTS competition**. For more information on the competition see the [competition website](https://sites.google.com/site/micrortsaicompetition/home). The previous competitions have been organized at IEEE-CIG2017 and IEEE-CIG2018, and this year it's organized at IEEE-COG2019 (notice the change of name of the conference).
 
@@ -14,9 +14,13 @@ To cite microRTS, please cite this paper:
 
 Santiago Ontañón (2013) The Combinatorial Multi-Armed Bandit Problem and its Application to Real-Time Strategy Games, In AIIDE 2013. pp. 58 - 64.
 
-## Instructions to build and run
+## Setting up microRTS
 
-To build and run microRTS using the Linux os Mac OS command line, run the following commands in the root folder of the project:
+Watch [this YouTube video](https://www.youtube.com/watch?v=_jVOMNqw3Qs) to learn how to acquire microRTS and setup a project using Netbeans.
+
+### Terminal commands
+
+If you want to build and run microRTS using the Linux or Mac OS command line, clone or download this repository and run the following commands in the root folder of the project:
 
 ```shell
 javac -cp "lib/*:src" -d bin src/rts/MicroRTS.java # to build

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 ## microrts
 
-microRTS is a small implementation of an RTS game, designed to perform AI research. The advantage of using microRTS with respect to using a full-fledged game like Wargus or Starcraft (using BWAPI) is that microRTS is much simpler, and can be used to quickly test theoretical ideas, before moving on to full-fledged RTS games.
+microRTS is a small implementation of an RTS game, designed to perform AI research. The advantage of using microRTS with respect to using a full-fledged game like Wargus or StarCraft (using BWAPI) is that microRTS is much simpler, and can be used to quickly test theoretical ideas, before moving on to full-fledged RTS games.
 
 microRTS is deterministic and real-time (i.e. players can issue actions simultaneously, and actions are durative). It is possible to experiment both with fully-observable and partially-observable games. Thus, it is not adequate for evaluating AI techniques designed to deal with non-determinism (although future versions of microRTS might include non-determinism activated via certain flags). As part of the implementation, I include a collection of hard-coded, and game-tree search techniques (such as variants of minimax, Monte Carlo search, and Monte Carlo Tree Search).
 
 microRTS was developed by [Santiago Ontañón](https://sites.google.com/site/santiagoontanonvillar/Home). 
 
-For a video of how microRTS looks like when a human plays see a [youtube video](https://www.youtube.com/watch?v=ZsKKAoiD7B0)
+For a video of how microRTS looks like when a human plays, see a [youtube video](https://www.youtube.com/watch?v=ZsKKAoiD7B0)
 
 If you are interested in testing your algorithms against other people's, **there is an annual microRTS competition**. For more information on the competition see the [competition website](https://sites.google.com/site/micrortsaicompetition/home). The previous competitions have been organized at IEEE-CIG2017 and IEEE-CIG2018, and this year it's organized at IEEE-COG2019 (notice the change of name of the conference).
 


### PR DESCRIPTION
This PR adds instructions on how to compile and run microRTS through the command line on Linux, Windows and Mac.

I was having trouble achieving this, but in https://github.com/santiontanon/microrts/commit/fccc4b9e97f556fea04203435a4e758f58fdbd22 I found the instructions on how to do so. I elaborated a little more on the instructions by @scheffield and also linked to a video by @santiontanon showing how to setup a project for microRTS on Netbeans.

A possible problem with this PR is that it adds information to the README. While I believe instructions on how to run the project are fundamental, If this is not desired, we can move them to the wiki and add a link to the README instead.