### PR TITLE
Add build status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## microrts
+# microRTS [![Build Status](https://travis-ci.org/douglasrizzo/microrts.svg?branch=master)](https://travis-ci.org/douglasrizzo/microrts)
 
 microRTS is a small implementation of an RTS game, designed to perform AI research. The advantage of using microRTS with respect to using a full-fledged game like Wargus or StarCraft (using BWAPI) is that microRTS is much simpler, and can be used to quickly test theoretical ideas, before moving on to full-fledged RTS games.
 


### PR DESCRIPTION
This PR adds the build status badge, provided by Travis CI, to the README.

The build status badge shows others that the code can be successfully compiled in its current state, as long as the steps in the `.travis.yml` file are followed.

This badge is linked to my fork of microrts. The owner of this repo can migrate it by following these steps:

* sign in to travis-ci.org using your GitHub account;
* activate automated testing of the `microrts` repository;
* point the badge in the README to santiontanon/microrts instead of douglasrizzo/microrts.