### PR TITLE
Fill and clear data structures without the use of loops

### DIFF
--- a/src/ai/abstraction/EMRDeterministico.java
+++ b/src/ai/abstraction/EMRDeterministico.java
@@ -217,8 +217,7 @@ public class EMRDeterministico extends AbstractionLayerAI {
         int resourcesUsed = 0;
         int nArmyUnits = 0;
 
-        List<Unit> freeWorkers = new ArrayList<>();
-        freeWorkers.addAll(workers);
+        List<Unit> freeWorkers = new ArrayList<>(workers);
 
         if (workers.isEmpty()) {
             return;

--- a/src/ai/abstraction/EconomyMilitaryRush.java
+++ b/src/ai/abstraction/EconomyMilitaryRush.java
@@ -234,8 +234,7 @@ public class EconomyMilitaryRush extends AbstractionLayerAI {
         int resourcesUsed = 0;
         int nArmyUnits = 0;
 
-        List<Unit> freeWorkers = new ArrayList<>();
-        freeWorkers.addAll(workers);
+        List<Unit> freeWorkers = new ArrayList<>(workers);
 
         if (workers.isEmpty()) {
             return;

--- a/src/ai/abstraction/EconomyRush.java
+++ b/src/ai/abstraction/EconomyRush.java
@@ -333,9 +333,7 @@ public class EconomyRush extends AbstractionLayerAI {
         Collections.sort(keysOrdered);
         
         for (Integer key : keysOrdered) {
-            for(Unit uTemp : map.get(key)){
-                resReturn.add(uTemp);
-            }
+            resReturn.addAll(map.get(key));
                 
         }
         

--- a/src/ai/abstraction/EconomyRush.java
+++ b/src/ai/abstraction/EconomyRush.java
@@ -233,8 +233,7 @@ public class EconomyRush extends AbstractionLayerAI {
         int nbases = 0;
         int nbarracks = 0;
 
-        List<Unit> freeWorkers = new ArrayList<>();
-        freeWorkers.addAll(workers);
+        List<Unit> freeWorkers = new ArrayList<>(workers);
 
         if (workers.isEmpty()) {
             return;

--- a/src/ai/abstraction/EconomyRushBurster.java
+++ b/src/ai/abstraction/EconomyRushBurster.java
@@ -223,8 +223,7 @@ public class EconomyRushBurster extends AbstractionLayerAI {
         int nbarracks = 0;
         int resourcesUsed = 0;
 
-        List<Unit> freeWorkers = new ArrayList<>();
-        freeWorkers.addAll(workers);
+        List<Unit> freeWorkers = new ArrayList<>(workers);
 
         if (workers.isEmpty()) {
             return;

--- a/src/ai/abstraction/HeavyDefense.java
+++ b/src/ai/abstraction/HeavyDefense.java
@@ -169,8 +169,7 @@ public class HeavyDefense extends AbstractionLayerAI {
         int nbarracks = 0;
 
         int resourcesUsed = 0;
-        List<Unit> freeWorkers = new LinkedList<>();
-        freeWorkers.addAll(workers);
+        List<Unit> freeWorkers = new LinkedList<>(workers);
 
         if (workers.isEmpty()) {
             return;

--- a/src/ai/abstraction/HeavyRush.java
+++ b/src/ai/abstraction/HeavyRush.java
@@ -162,8 +162,7 @@ public class HeavyRush extends AbstractionLayerAI {
         int nbarracks = 0;
 
         int resourcesUsed = 0;
-        List<Unit> freeWorkers = new LinkedList<>();
-        freeWorkers.addAll(workers);
+        List<Unit> freeWorkers = new LinkedList<>(workers);
 
         if (workers.isEmpty()) {
             return;

--- a/src/ai/abstraction/LightDefense.java
+++ b/src/ai/abstraction/LightDefense.java
@@ -172,8 +172,7 @@ public class LightDefense extends AbstractionLayerAI {
         int nbarracks = 0;
 
         int resourcesUsed = 0;
-        List<Unit> freeWorkers = new LinkedList<>();
-        freeWorkers.addAll(workers);
+        List<Unit> freeWorkers = new LinkedList<>(workers);
 
         if (workers.isEmpty()) {
             return;

--- a/src/ai/abstraction/LightRush.java
+++ b/src/ai/abstraction/LightRush.java
@@ -163,8 +163,7 @@ public class LightRush extends AbstractionLayerAI {
         int nbarracks = 0;
 
         int resourcesUsed = 0;
-        List<Unit> freeWorkers = new LinkedList<>();
-        freeWorkers.addAll(workers);
+        List<Unit> freeWorkers = new LinkedList<>(workers);
 
         if (workers.isEmpty()) {
             return;

--- a/src/ai/abstraction/RangedDefense.java
+++ b/src/ai/abstraction/RangedDefense.java
@@ -160,8 +160,7 @@ public class RangedDefense extends AbstractionLayerAI {
         int nbarracks = 0;
 
         int resourcesUsed = 0;
-        List<Unit> freeWorkers = new LinkedList<>();
-        freeWorkers.addAll(workers);
+        List<Unit> freeWorkers = new LinkedList<>(workers);
 
         if (workers.isEmpty()) {
             return;

--- a/src/ai/abstraction/RangedRush.java
+++ b/src/ai/abstraction/RangedRush.java
@@ -150,8 +150,7 @@ public class RangedRush extends AbstractionLayerAI {
         int nbarracks = 0;
 
         int resourcesUsed = 0;
-        List<Unit> freeWorkers = new LinkedList<>();
-        freeWorkers.addAll(workers);
+        List<Unit> freeWorkers = new LinkedList<>(workers);
 
         if (workers.isEmpty()) {
             return;

--- a/src/ai/abstraction/SimpleEconomyRush.java
+++ b/src/ai/abstraction/SimpleEconomyRush.java
@@ -226,8 +226,7 @@ public class SimpleEconomyRush extends AbstractionLayerAI {
         int nbarracks = 0;
 
         int resourcesUsed = 0;
-        List<Unit> freeWorkers = new ArrayList<>();
-        freeWorkers.addAll(workers);
+        List<Unit> freeWorkers = new ArrayList<>(workers);
 
         if (workers.isEmpty()) {
             return;

--- a/src/ai/abstraction/WorkerDefense.java
+++ b/src/ai/abstraction/WorkerDefense.java
@@ -149,8 +149,7 @@ public class WorkerDefense extends AbstractionLayerAI {
         int nbases = 0;
         int resourcesUsed = 0;
         Unit harvestWorker = null;
-        List<Unit> freeWorkers = new LinkedList<>();
-        freeWorkers.addAll(workers);
+        List<Unit> freeWorkers = new LinkedList<>(workers);
         
         if (workers.isEmpty()) return;
         

--- a/src/ai/abstraction/WorkerRush.java
+++ b/src/ai/abstraction/WorkerRush.java
@@ -126,8 +126,7 @@ public class WorkerRush extends AbstractionLayerAI {
         int nbases = 0;
         int resourcesUsed = 0;
         Unit harvestWorker = null;
-        List<Unit> freeWorkers = new LinkedList<>();
-        freeWorkers.addAll(workers);
+        List<Unit> freeWorkers = new LinkedList<>(workers);
         
         if (workers.isEmpty()) return;
         

--- a/src/ai/abstraction/WorkerRushPlusPlus.java
+++ b/src/ai/abstraction/WorkerRushPlusPlus.java
@@ -148,8 +148,7 @@ public class WorkerRushPlusPlus extends AbstractionLayerAI {
         int nbases = 0;
         int resourcesUsed = 0;
         Unit harvestWorker = null;
-        List<Unit> freeWorkers = new LinkedList<>();
-        freeWorkers.addAll(workers);
+        List<Unit> freeWorkers = new LinkedList<>(workers);
         
         if (workers.isEmpty()) return;
         

--- a/src/ai/ahtn/domain/MethodDecomposition.java
+++ b/src/ai/ahtn/domain/MethodDecomposition.java
@@ -8,7 +8,7 @@ package ai.ahtn.domain;
 
 import ai.ahtn.domain.LispParser.LispElement;
 import ai.ahtn.planner.AdversarialChoicePoint;
-import java.util.Collections;
+
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.ArrayList;

--- a/src/ai/ahtn/visualization/HTNDomainVisualizer.java
+++ b/src/ai/ahtn/visualization/HTNDomainVisualizer.java
@@ -18,6 +18,7 @@ import java.awt.FontMetrics;
 import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
 import java.io.File;
+import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import javax.imageio.ImageIO;
@@ -165,14 +166,10 @@ public class HTNDomainVisualizer {
                         children.add(md.getTerm().getFunctor());
                         break;
                 case MethodDecomposition.METHOD_SEQUENCE:
-                        for(MethodDecomposition md2:md.getSubparts()) {
-                            stack.add(md2);
-                        }
+                    stack.addAll(Arrays.asList(md.getSubparts()));
                         break;
                 case MethodDecomposition.METHOD_PARALLEL:
-                        for(MethodDecomposition md2:md.getSubparts()) {
-                            stack.add(md2);
-                        }
+                    stack.addAll(Arrays.asList(md.getSubparts()));
                         break;
                 case MethodDecomposition.METHOD_CONDITION:
                         break;
@@ -262,14 +259,10 @@ public class HTNDomainVisualizer {
                         }
                         break;
                 case MethodDecomposition.METHOD_SEQUENCE:
-                        for(MethodDecomposition md2:md.getSubparts()) {
-                            stack.add(md2);
-                        }
+                    stack.addAll(Arrays.asList(md.getSubparts()));
                         break;
                 case MethodDecomposition.METHOD_PARALLEL:
-                        for(MethodDecomposition md2:md.getSubparts()) {
-                            stack.add(md2);
-                        }
+                    stack.addAll(Arrays.asList(md.getSubparts()));
                         break;
                 case MethodDecomposition.METHOD_CONDITION:
                         break;
@@ -352,14 +345,10 @@ public class HTNDomainVisualizer {
                         }
                         break;
                 case MethodDecomposition.METHOD_SEQUENCE:
-                        for(MethodDecomposition md2:md.getSubparts()) {
-                            stack.add(md2);
-                        }
+                    stack.addAll(Arrays.asList(md.getSubparts()));
                         break;
                 case MethodDecomposition.METHOD_PARALLEL:
-                        for(MethodDecomposition md2:md.getSubparts()) {
-                            stack.add(md2);
-                        }
+                    stack.addAll(Arrays.asList(md.getSubparts()));
                         break;
                 case MethodDecomposition.METHOD_CONDITION:
                         break;

--- a/src/ai/ahtn/visualization/HTNDomainVisualizerVertical.java
+++ b/src/ai/ahtn/visualization/HTNDomainVisualizerVertical.java
@@ -17,6 +17,7 @@ import java.awt.FontMetrics;
 import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
 import java.io.File;
+import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import javax.imageio.ImageIO;
@@ -169,14 +170,10 @@ public class HTNDomainVisualizerVertical {
                         children.add(md.getTerm().getFunctor());
                         break;
                 case MethodDecomposition.METHOD_SEQUENCE:
-                        for(MethodDecomposition md2:md.getSubparts()) {
-                            stack.add(md2);
-                        }
+                    stack.addAll(Arrays.asList(md.getSubparts()));
                         break;
                 case MethodDecomposition.METHOD_PARALLEL:
-                        for(MethodDecomposition md2:md.getSubparts()) {
-                            stack.add(md2);
-                        }
+                    stack.addAll(Arrays.asList(md.getSubparts()));
                         break;
                 case MethodDecomposition.METHOD_CONDITION:
                         break;
@@ -268,14 +265,10 @@ public class HTNDomainVisualizerVertical {
                         }
                         break;
                 case MethodDecomposition.METHOD_SEQUENCE:
-                        for(MethodDecomposition md2:md.getSubparts()) {
-                            stack.add(md2);
-                        }
+                    stack.addAll(Arrays.asList(md.getSubparts()));
                         break;
                 case MethodDecomposition.METHOD_PARALLEL:
-                        for(MethodDecomposition md2:md.getSubparts()) {
-                            stack.add(md2);
-                        }
+                    stack.addAll(Arrays.asList(md.getSubparts()));
                         break;
                 case MethodDecomposition.METHOD_CONDITION:
                         break;
@@ -344,14 +337,10 @@ public class HTNDomainVisualizerVertical {
                         }
                         break;
                 case MethodDecomposition.METHOD_SEQUENCE:
-                        for(MethodDecomposition md2:md.getSubparts()) {
-                            stack.add(md2);
-                        }
+                    stack.addAll(Arrays.asList(md.getSubparts()));
                         break;
                 case MethodDecomposition.METHOD_PARALLEL:
-                        for(MethodDecomposition md2:md.getSubparts()) {
-                            stack.add(md2);
-                        }
+                    stack.addAll(Arrays.asList(md.getSubparts()));
                         break;
                 case MethodDecomposition.METHOD_CONDITION:
                         break;

--- a/src/ai/machinelearning/bayes/ActionInterdependenceModel.java
+++ b/src/ai/machinelearning/bayes/ActionInterdependenceModel.java
@@ -499,7 +499,7 @@ public class ActionInterdependenceModel extends BayesianModel {
             for(int i = 0;i<nfeatures;i++) {
                 if (!bestSelection[i]) {
                     boolean currentSelection[] = new boolean[nfeatures];
-                    for(int j = 0;j<nfeatures;j++) currentSelection[j] = bestSelection[j];
+                    System.arraycopy(bestSelection, 0, currentSelection, 0, nfeatures);
                     currentSelection[i] = true;
 
                     selectedFeatures = currentSelection;

--- a/src/ai/machinelearning/bayes/CalibratedNaiveBayes.java
+++ b/src/ai/machinelearning/bayes/CalibratedNaiveBayes.java
@@ -325,7 +325,7 @@ public class CalibratedNaiveBayes extends BayesianModel {
             for(int i = 0;i<nfeatures;i++) {
                 if (!bestSelection[i]) {
                     boolean currentSelection[] = new boolean[nfeatures];
-                    for(int j = 0;j<nfeatures;j++) currentSelection[j] = bestSelection[j];
+                    System.arraycopy(bestSelection, 0, currentSelection, 0, nfeatures);
                     currentSelection[i] = true;
 
                     selectedFeatures = currentSelection;

--- a/src/ai/mcts/believestatemcts/BS1_NaiveMCTS.java
+++ b/src/ai/mcts/believestatemcts/BS1_NaiveMCTS.java
@@ -146,8 +146,7 @@ public class BS1_NaiveMCTS extends NaiveMCTS implements AIWithBelieveState {
 
     @Override
     public List<Unit> getBelieveUnits() {
-        List<Unit> l = new LinkedList<>();
-        l.addAll(lastKnownPosition);
+        List<Unit> l = new LinkedList<>(lastKnownPosition);
         return l;
     }
 

--- a/src/ai/mcts/believestatemcts/BS2_NaiveMCTS.java
+++ b/src/ai/mcts/believestatemcts/BS2_NaiveMCTS.java
@@ -121,8 +121,7 @@ public class BS2_NaiveMCTS extends NaiveMCTS implements AIWithBelieveState {
 
     @Override
     public List<Unit> getBelieveUnits() {
-        List<Unit> l = new LinkedList<>();
-        l.addAll(lastKnownPosition);
+        List<Unit> l = new LinkedList<>(lastKnownPosition);
         return l;
     }
 

--- a/src/ai/mcts/mlps/MLPSNode.java
+++ b/src/ai/mcts/mlps/MLPSNode.java
@@ -186,8 +186,7 @@ public class MLPSNode extends MCTSNode {
             double accumUCBScore = 0;
             double maxExplorationScore = 0;
             pa2.setResourceUsage(base_ru.clone());
-            List<Integer> notSampledYetIDs2 = new LinkedList<>();
-            notSampledYetIDs2.addAll(notSampledYetIDs);
+            List<Integer> notSampledYetIDs2 = new LinkedList<>(notSampledYetIDs);
             while(!notSampledYetIDs2.isEmpty()) {            
                 if (DEBUG>=2) System.out.println("notSampledYet: " + notSampledYetIDs2);
                 int i = r.nextInt(notSampledYetIDs2.size());

--- a/src/ai/montecarlo/lsi/LSI.java
+++ b/src/ai/montecarlo/lsi/LSI.java
@@ -15,7 +15,6 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Random;
 import java.util.Set;

--- a/src/ai/puppet/BasicConfigurableScript.java
+++ b/src/ai/puppet/BasicConfigurableScript.java
@@ -252,9 +252,8 @@ public class BasicConfigurableScript extends ConfigurableScript<BasicChoicePoint
                 bases.add(u2);
             }
         }
-        
-        List<Unit> freeWorkers = new LinkedList<>();
-        freeWorkers.addAll(workers);
+
+        List<Unit> freeWorkers = new LinkedList<>(workers);
         List<Integer> reservedPositions = new LinkedList<>();
         if (nbases == 0 && !freeWorkers.isEmpty()) {
             // build a base:

--- a/src/gui/PGSMouseListener.java
+++ b/src/gui/PGSMouseListener.java
@@ -329,8 +329,7 @@ public class PGSMouseListener implements MouseListener, MouseMotionListener, Key
         List<UnitType> shared = null;
         for(Unit u:selectedUnits) {
             if (shared==null) {
-                shared = new ArrayList<>();
-                shared.addAll(u.getType().produces);
+                shared = new ArrayList<>(u.getType().produces);
             } else {
                 List<UnitType> toDelete = new ArrayList<>();
                 for(UnitType ut:shared) {

--- a/src/gui/PhysicalGameStatePanel.java
+++ b/src/gui/PhysicalGameStatePanel.java
@@ -352,8 +352,7 @@ public class PhysicalGameStatePanel extends JPanel {
 
         // draw the units:
         // this list copy is to prevent a concurrent modification exception
-        List<Unit> l = new LinkedList<>();
-        l.addAll(pgs.getUnits());
+        List<Unit> l = new LinkedList<>(pgs.getUnits());
         for(Unit u:l) {
             int reduction = 0;
 

--- a/src/rts/GameState.java
+++ b/src/rts/GameState.java
@@ -552,7 +552,7 @@ public class GameState {
      */
     public void forceExecuteAllActions() {
         List<UnitActionAssignment> readyToExecute = new LinkedList<>();
-        for(UnitActionAssignment uaa:unitActions.values()) readyToExecute.add(uaa);
+        readyToExecute.addAll(unitActions.values());
                 
         // execute all the actions:
         for(UnitActionAssignment uaa:readyToExecute) {

--- a/src/rts/GameState.java
+++ b/src/rts/GameState.java
@@ -551,8 +551,7 @@ public class GameState {
      * Forces the execution of all assigned actions
      */
     public void forceExecuteAllActions() {
-        List<UnitActionAssignment> readyToExecute = new LinkedList<>();
-        readyToExecute.addAll(unitActions.values());
+        List<UnitActionAssignment> readyToExecute = new LinkedList<>(unitActions.values());
                 
         // execute all the actions:
         for(UnitActionAssignment uaa:readyToExecute) {

--- a/src/rts/PhysicalGameState.java
+++ b/src/rts/PhysicalGameState.java
@@ -374,12 +374,8 @@ public class PhysicalGameState {
      */
     public PhysicalGameState cloneKeepingUnits() {
         PhysicalGameState pgs = new PhysicalGameState(width, height, terrain);  // The terrain is shared amongst all instances, since it never changes
-        for (Player p : players) {
-            pgs.players.add(p);
-        }
-        for (Unit u : units) {
-            pgs.units.add(u);
-        }
+        pgs.players.addAll(players);
+        pgs.units.addAll(units);
         return pgs;
     }
 

--- a/src/rts/PhysicalGameState.java
+++ b/src/rts/PhysicalGameState.java
@@ -386,9 +386,7 @@ public class PhysicalGameState {
      */
     public PhysicalGameState cloneIncludingTerrain() {
         int new_terrain[] = new int[terrain.length];
-        for (int i = 0; i < terrain.length; i++) {
-            new_terrain[i] = terrain[i];
-        }
+        System.arraycopy(terrain, 0, new_terrain, 0, terrain.length);
         PhysicalGameState pgs = new PhysicalGameState(width, height, new_terrain);
         for (Player p : players) {
             pgs.players.add(p.clone());

--- a/src/rts/PlayerAction.java
+++ b/src/rts/PlayerAction.java
@@ -140,8 +140,8 @@ public class PlayerAction {
      */
     public PlayerAction merge(PlayerAction a) {
         PlayerAction merge = new PlayerAction();
-        for(Pair<Unit,UnitAction> ua : actions) merge.actions.add(ua);
-        for(Pair<Unit,UnitAction> ua : a.actions) merge.actions.add(ua);
+        merge.actions.addAll(actions);
+        merge.actions.addAll(a.actions);
         merge.r = r.mergeIntoNew(a.r);
         
         return merge;

--- a/src/rts/PlayerActionGenerator.java
+++ b/src/rts/PlayerActionGenerator.java
@@ -109,8 +109,7 @@ public class PlayerActionGenerator {
      */
     public void randomizeOrder() {
 		for (Pair<Unit, List<UnitAction>> choice : choices) {
-			List<UnitAction> tmp = new LinkedList<>();
-			tmp.addAll(choice.m_b);
+            List<UnitAction> tmp = new LinkedList<>(choice.m_b);
 			choice.m_b.clear();
 			while (!tmp.isEmpty())
 				choice.m_b.add(tmp.remove(r.nextInt(tmp.size())));
@@ -197,8 +196,7 @@ public class PlayerActionGenerator {
 		PlayerAction pa = new PlayerAction();
 		pa.setResourceUsage(base_ru.clone());
 		for (Pair<Unit, List<UnitAction>> unitChoices : choices) {
-			List<UnitAction> l = new LinkedList<>();
-			l.addAll(unitChoices.m_b);
+            List<UnitAction> l = new LinkedList<>(unitChoices.m_b);
 			Unit u = unitChoices.m_a;
 
 			boolean consistent = false;

--- a/src/tests/AbstractTraceGenerationTest.java
+++ b/src/tests/AbstractTraceGenerationTest.java
@@ -13,7 +13,7 @@ import ai.abstraction.AbstractionLayerAI;
 import ai.abstraction.LightRush;
 import ai.abstraction.pathfinding.BFSPathFinding;
 import java.io.FileWriter;
-import java.io.IOException;
+
 import rts.*;
 import rts.units.Unit;
 import rts.units.UnitTypeTable;

--- a/src/tests/CompareAllAIsObservable.java
+++ b/src/tests/CompareAllAIsObservable.java
@@ -103,7 +103,6 @@ public class CompareAllAIsObservable {
         // Separate the matchs by map:
         List<PhysicalGameState> maps = new LinkedList<>();
 
-        maps.clear();
         maps.add(PhysicalGameState.load("maps/8x8/basesWorkers8x8.xml",utt));
 //        Experimenter.runExperimentsPartiallyObservable(bots, maps, 10, 3000, 300, true, out);
         Experimenter.runExperiments(bots, maps, utt, 10, 3000, 300, true, out);

--- a/src/tests/CompareAllAIsPartiallyObservable.java
+++ b/src/tests/CompareAllAIsPartiallyObservable.java
@@ -103,7 +103,6 @@ public class CompareAllAIsPartiallyObservable {
         // Separate the matchs by map:
         List<PhysicalGameState> maps = new LinkedList<>();
 
-        maps.clear();
         maps.add(PhysicalGameState.load("maps/8x8/basesWorkers8x8.xml",utt));
         Experimenter.runExperimentsPartiallyObservable(bots, maps, utt, 10, 3000, 300, true, out);
       


### PR DESCRIPTION
As requested, this PR contains a subset of the changes from #54. Specifically, I employ methods such as `addAll`, `fill`, `clear`, `arraycopy` and constructors to avoid loops when populating and clearing data structures.