### PR TITLE
Simplify booleans

### DIFF
--- a/src/ai/abstraction/Attack.java
+++ b/src/ai/abstraction/Attack.java
@@ -38,9 +38,7 @@ public class Attack extends AbstractAction  {
     {
         if (!(o instanceof Attack)) return false;
         Attack a = (Attack)o;
-        if (target.getID() != a.target.getID()) return false;
-        if (pf.getClass() != a.pf.getClass()) return false;
-        
+        if (target.getID() != a.target.getID()||pf.getClass() != a.pf.getClass()) return false;
         return true;
     }
 

--- a/src/ai/abstraction/Attack.java
+++ b/src/ai/abstraction/Attack.java
@@ -29,8 +29,7 @@ public class Attack extends AbstractAction  {
     
     public boolean completed(GameState gs) {
         PhysicalGameState pgs = gs.getPhysicalGameState();
-        if (!pgs.getUnits().contains(target)) return true;
-        return false;
+        return !pgs.getUnits().contains(target);
     }
     
     
@@ -38,8 +37,7 @@ public class Attack extends AbstractAction  {
     {
         if (!(o instanceof Attack)) return false;
         Attack a = (Attack)o;
-        if (target.getID() != a.target.getID()||pf.getClass() != a.pf.getClass()) return false;
-        return true;
+        return target.getID() == a.target.getID() && pf.getClass() == a.pf.getClass();
     }
 
     

--- a/src/ai/abstraction/Build.java
+++ b/src/ai/abstraction/Build.java
@@ -33,8 +33,7 @@ public class Build extends AbstractAction  {
     public boolean completed(GameState gs) {
         PhysicalGameState pgs = gs.getPhysicalGameState();
         Unit u = pgs.getUnitAt(x, y);
-        if (u!=null) return true;
-        return false;
+        return u != null;
     }
     
     
@@ -42,8 +41,7 @@ public class Build extends AbstractAction  {
     {
         if (!(o instanceof Build)) return false;
         Build a = (Build)o;
-        if (type != a.type||x != a.x||y != a.y||pf.getClass() != a.pf.getClass()) return false;
-        return true;
+        return type == a.type && x == a.x && y == a.y && pf.getClass() == a.pf.getClass();
     }
     
 

--- a/src/ai/abstraction/Build.java
+++ b/src/ai/abstraction/Build.java
@@ -42,11 +42,7 @@ public class Build extends AbstractAction  {
     {
         if (!(o instanceof Build)) return false;
         Build a = (Build)o;
-        if (type != a.type) return false;
-        if (x != a.x) return false;
-        if (y != a.y) return false;
-        if (pf.getClass() != a.pf.getClass()) return false;
-        
+        if (type != a.type||x != a.x||y != a.y||pf.getClass() != a.pf.getClass()) return false;
         return true;
     }
     

--- a/src/ai/abstraction/Harvest.java
+++ b/src/ai/abstraction/Harvest.java
@@ -40,8 +40,7 @@ public class Harvest extends AbstractAction  {
     
     
     public boolean completed(GameState gs) {
-        if (!gs.getPhysicalGameState().getUnits().contains(target)) return true;
-        return false;
+        return !gs.getPhysicalGameState().getUnits().contains(target);
     }
     
     
@@ -49,11 +48,8 @@ public class Harvest extends AbstractAction  {
     {
         if (!(o instanceof Harvest)) return false;
         Harvest a = (Harvest)o;
-        if (target.getID() != a.target.getID()) return false;
-        if (base.getID() != a.base.getID()) return false;
-        if (pf.getClass() != a.pf.getClass()) return false;
-        
-        return true;
+        return target.getID() == a.target.getID() && base.getID() == a.base.getID()
+            && pf.getClass() == a.pf.getClass();
     }
     
 

--- a/src/ai/abstraction/Idle.java
+++ b/src/ai/abstraction/Idle.java
@@ -28,8 +28,7 @@ public class Idle extends AbstractAction  {
     
     public boolean equals(Object o)
     {
-        if (!(o instanceof Idle)) return false;        
-        return true;
+        return o instanceof Idle;
     }
 
     

--- a/src/ai/abstraction/Move.java
+++ b/src/ai/abstraction/Move.java
@@ -39,9 +39,7 @@ public class Move extends AbstractAction {
     {
         if (!(o instanceof Move)) return false;
         Move a = (Move)o;
-        if (x != a.x) return false;
-        if (y != a.y) return false;
-        if (pf.getClass() != a.pf.getClass()) return false;
+        if (x != a.x||y != a.y||pf.getClass() != a.pf.getClass()) return false;
         
         return true;
     }

--- a/src/ai/abstraction/Move.java
+++ b/src/ai/abstraction/Move.java
@@ -30,8 +30,7 @@ public class Move extends AbstractAction {
     }
     
     public boolean completed(GameState gs) {
-        if (unit.getX()==x && unit.getY()==y) return true;
-        return false;
+        return unit.getX() == x && unit.getY() == y;
     }
     
     
@@ -39,9 +38,7 @@ public class Move extends AbstractAction {
     {
         if (!(o instanceof Move)) return false;
         Move a = (Move)o;
-        if (x != a.x||y != a.y||pf.getClass() != a.pf.getClass()) return false;
-        
-        return true;
+        return x == a.x && y == a.y && pf.getClass() == a.pf.getClass();
     }
 
     

--- a/src/ai/abstraction/Train.java
+++ b/src/ai/abstraction/Train.java
@@ -35,9 +35,7 @@ public class Train extends AbstractAction {
     {
         if (!(o instanceof Train)) return false;
         Train a = (Train)o;
-        if (type != a.type) return false;
-        
-        return true;
+        return type == a.type;
     }
     
     

--- a/src/ai/abstraction/cRush/CRanged_Tactic.java
+++ b/src/ai/abstraction/cRush/CRanged_Tactic.java
@@ -69,10 +69,7 @@ public class CRanged_Tactic extends AbstractAction {
             return false;
         }
         CRanged_Tactic a = (CRanged_Tactic) o;
-        if (target.getID() != a.target.getID()) {
-            return false;
-        }
-        if (pf.getClass() != a.pf.getClass()) {
+        if (target.getID() != a.target.getID()||pf.getClass() != a.pf.getClass()) {
             return false;
         }
 

--- a/src/ai/abstraction/cRush/CRanged_Tactic.java
+++ b/src/ai/abstraction/cRush/CRanged_Tactic.java
@@ -58,10 +58,7 @@ public class CRanged_Tactic extends AbstractAction {
 
     public boolean completed(GameState gs) {
         PhysicalGameState pgs = gs.getPhysicalGameState();
-        if (!pgs.getUnits().contains(target)) {
-            return true;
-        }
-        return false;
+        return !pgs.getUnits().contains(target);
     }
 
     public boolean equals(Object o) {
@@ -69,11 +66,7 @@ public class CRanged_Tactic extends AbstractAction {
             return false;
         }
         CRanged_Tactic a = (CRanged_Tactic) o;
-        if (target.getID() != a.target.getID()||pf.getClass() != a.pf.getClass()) {
-            return false;
-        }
-
-        return true;
+        return target.getID() == a.target.getID() && pf.getClass() == a.pf.getClass();
     }
 
     public void toxml(XMLWriter w) {

--- a/src/ai/abstraction/cRush/RangedAttack.java
+++ b/src/ai/abstraction/cRush/RangedAttack.java
@@ -35,8 +35,7 @@ public class RangedAttack extends AbstractAction  {
     
     public boolean completed(GameState gs) {
         PhysicalGameState pgs = gs.getPhysicalGameState();
-        if (!pgs.getUnits().contains(target)) return true;
-        return false;
+        return !pgs.getUnits().contains(target);
     }
     
     
@@ -44,9 +43,8 @@ public class RangedAttack extends AbstractAction  {
     {
         if (!(o instanceof RangedAttack)) return false;
         RangedAttack a = (RangedAttack)o;
-        if (target.getID() != a.target.getID()||pf.getClass() != a.pf.getClass()||racks.getID() != a.racks.getID()) return false;
-        
-        return true;
+        return target.getID() == a.target.getID() && pf.getClass() == a.pf.getClass()
+            && racks.getID() == a.racks.getID();
     }
 
     

--- a/src/ai/abstraction/cRush/RangedAttack.java
+++ b/src/ai/abstraction/cRush/RangedAttack.java
@@ -44,9 +44,7 @@ public class RangedAttack extends AbstractAction  {
     {
         if (!(o instanceof RangedAttack)) return false;
         RangedAttack a = (RangedAttack)o;
-        if (target.getID() != a.target.getID()) return false;
-        if (pf.getClass() != a.pf.getClass()) return false;
-        if (racks.getID() != a.racks.getID()) return false;
+        if (target.getID() != a.target.getID()||pf.getClass() != a.pf.getClass()||racks.getID() != a.racks.getID()) return false;
         
         return true;
     }

--- a/src/ai/abstraction/pathfinding/AStarPathFinding.java
+++ b/src/ai/abstraction/pathfinding/AStarPathFinding.java
@@ -190,8 +190,7 @@ public class AStarPathFinding extends PathFinding {
     }      
 
     public boolean pathExists(Unit start, int targetpos, GameState gs, ResourceUsage ru) {
-        if (start.getPosition(gs.getPhysicalGameState())==targetpos) return true;
-        if (findPath(start,targetpos,gs,ru)!=null) return true;
+        if (start.getPosition(gs.getPhysicalGameState())==targetpos||findPath(start,targetpos,gs,ru)!=null) return true;
         return false;
     }
     
@@ -200,8 +199,7 @@ public class AStarPathFinding extends PathFinding {
         int x = targetpos%gs.getPhysicalGameState().getWidth();
         int y = targetpos/gs.getPhysicalGameState().getWidth();
         int d = (x-start.getX())*(x-start.getX()) + (y-start.getY())*(y-start.getY());
-        if (d<=range*range) return true;
-        if (findPathToPositionInRange(start,targetpos,range,gs,ru)!=null) return true;
+        if (d<=range*range||findPathToPositionInRange(start,targetpos,range,gs,ru)!=null) return true;
         return false;
     }
     

--- a/src/ai/abstraction/pathfinding/AStarPathFinding.java
+++ b/src/ai/abstraction/pathfinding/AStarPathFinding.java
@@ -190,8 +190,8 @@ public class AStarPathFinding extends PathFinding {
     }      
 
     public boolean pathExists(Unit start, int targetpos, GameState gs, ResourceUsage ru) {
-        if (start.getPosition(gs.getPhysicalGameState())==targetpos||findPath(start,targetpos,gs,ru)!=null) return true;
-        return false;
+        return start.getPosition(gs.getPhysicalGameState()) == targetpos
+            || findPath(start, targetpos, gs, ru) != null;
     }
     
 
@@ -199,8 +199,8 @@ public class AStarPathFinding extends PathFinding {
         int x = targetpos%gs.getPhysicalGameState().getWidth();
         int y = targetpos/gs.getPhysicalGameState().getWidth();
         int d = (x-start.getX())*(x-start.getX()) + (y-start.getY())*(y-start.getY());
-        if (d<=range*range||findPathToPositionInRange(start,targetpos,range,gs,ru)!=null) return true;
-        return false;
+        return d <= range * range
+            || findPathToPositionInRange(start, targetpos, range, gs, ru) != null;
     }
     
     // and keep the "open" list sorted:

--- a/src/ai/abstraction/pathfinding/BFSPathFinding.java
+++ b/src/ai/abstraction/pathfinding/BFSPathFinding.java
@@ -155,8 +155,8 @@ public class BFSPathFinding extends PathFinding {
     }      
 
     public boolean pathExists(Unit start, int targetpos, GameState gs, ResourceUsage ru) {
-        if (start.getPosition(gs.getPhysicalGameState())==targetpos||findPath(start,targetpos,gs,ru)!=null) return true;
-        return false;
+        return start.getPosition(gs.getPhysicalGameState()) == targetpos
+            || findPath(start, targetpos, gs, ru) != null;
     }
     
 
@@ -164,9 +164,8 @@ public class BFSPathFinding extends PathFinding {
         int x = targetpos%gs.getPhysicalGameState().getWidth();
         int y = targetpos/gs.getPhysicalGameState().getWidth();
         int d = (x-start.getX())*(x-start.getX()) + (y-start.getY())*(y-start.getY());
-        if (d<=range*range) return true;
-        if (findPathToPositionInRange(start,targetpos,range,gs,ru)!=null) return true;
-        return false;
+        return d <= range * range
+            || findPathToPositionInRange(start, targetpos, range, gs, ru) != null;
     }
         
 }

--- a/src/ai/abstraction/pathfinding/BFSPathFinding.java
+++ b/src/ai/abstraction/pathfinding/BFSPathFinding.java
@@ -155,8 +155,7 @@ public class BFSPathFinding extends PathFinding {
     }      
 
     public boolean pathExists(Unit start, int targetpos, GameState gs, ResourceUsage ru) {
-        if (start.getPosition(gs.getPhysicalGameState())==targetpos) return true;
-        if (findPath(start,targetpos,gs,ru)!=null) return true;
+        if (start.getPosition(gs.getPhysicalGameState())==targetpos||findPath(start,targetpos,gs,ru)!=null) return true;
         return false;
     }
     

--- a/src/ai/abstraction/pathfinding/FloodFillPathFinding.java
+++ b/src/ai/abstraction/pathfinding/FloodFillPathFinding.java
@@ -21,8 +21,7 @@ public class FloodFillPathFinding extends PathFinding {
 	int lastFrame=-1;
 	@Override
 	public boolean pathExists(Unit start, int targetpos, GameState gs, ResourceUsage ru) {
-		if (start.getPosition(gs.getPhysicalGameState())==targetpos) return true;
-        if (findPath(start,targetpos,gs,ru)!=null) return true;
+		if (start.getPosition(gs.getPhysicalGameState())==targetpos||findPath(start,targetpos,gs,ru)!=null) return true;
         return false;
 	}
 
@@ -31,8 +30,7 @@ public class FloodFillPathFinding extends PathFinding {
 		int x = targetpos%gs.getPhysicalGameState().getWidth();
         int y = targetpos/gs.getPhysicalGameState().getWidth();
         int d = (x-start.getX())*(x-start.getX()) + (y-start.getY())*(y-start.getY());
-        if (d<=range*range) return true;
-        if (findPathToPositionInRange(start,targetpos,range,gs,ru)!=null) return true;
+        if (d<=range*range||findPathToPositionInRange(start,targetpos,range,gs,ru)!=null) return true;
         return false;
 	}
 

--- a/src/ai/abstraction/pathfinding/FloodFillPathFinding.java
+++ b/src/ai/abstraction/pathfinding/FloodFillPathFinding.java
@@ -21,18 +21,18 @@ public class FloodFillPathFinding extends PathFinding {
 	int lastFrame=-1;
 	@Override
 	public boolean pathExists(Unit start, int targetpos, GameState gs, ResourceUsage ru) {
-		if (start.getPosition(gs.getPhysicalGameState())==targetpos||findPath(start,targetpos,gs,ru)!=null) return true;
-        return false;
-	}
+        return start.getPosition(gs.getPhysicalGameState()) == targetpos
+            || findPath(start, targetpos, gs, ru) != null;
+    }
 
 	@Override
 	public boolean pathToPositionInRangeExists(Unit start, int targetpos, int range, GameState gs, ResourceUsage ru) {
 		int x = targetpos%gs.getPhysicalGameState().getWidth();
         int y = targetpos/gs.getPhysicalGameState().getWidth();
         int d = (x-start.getX())*(x-start.getX()) + (y-start.getY())*(y-start.getY());
-        if (d<=range*range||findPathToPositionInRange(start,targetpos,range,gs,ru)!=null) return true;
-        return false;
-	}
+        return d <= range * range
+            || findPathToPositionInRange(start, targetpos, range, gs, ru) != null;
+    }
 
 	@Override
 	public UnitAction findPath(Unit start, int targetpos, GameState gs, ResourceUsage ru) {

--- a/src/ai/abstraction/pathfinding/GreedyPathFinding.java
+++ b/src/ai/abstraction/pathfinding/GreedyPathFinding.java
@@ -96,8 +96,7 @@ public class GreedyPathFinding extends PathFinding {
     
     
     public boolean pathExists(Unit start, int targetpos, GameState gs, ResourceUsage ru) {
-        if (start.getPosition(gs.getPhysicalGameState())==targetpos) return true;
-        if (findPath(start,targetpos,gs,ru)!=null) return true;
+        if (start.getPosition(gs.getPhysicalGameState())==targetpos||findPath(start,targetpos,gs,ru)!=null) return true;
         return false;
     }
     
@@ -106,8 +105,7 @@ public class GreedyPathFinding extends PathFinding {
         int x = targetpos%gs.getPhysicalGameState().getWidth();
         int y = targetpos/gs.getPhysicalGameState().getWidth();
         int d = (x-start.getX())*(x-start.getX()) + (y-start.getY())*(y-start.getY());
-        if (d<=range*range) return true;
-        if (findPathToPositionInRange(start,targetpos,range,gs,ru)!=null) return true;
+        if (d<=range*range||findPathToPositionInRange(start,targetpos,range,gs,ru)!=null) return true;
         return false;
     }
         

--- a/src/ai/abstraction/pathfinding/GreedyPathFinding.java
+++ b/src/ai/abstraction/pathfinding/GreedyPathFinding.java
@@ -96,8 +96,8 @@ public class GreedyPathFinding extends PathFinding {
     
     
     public boolean pathExists(Unit start, int targetpos, GameState gs, ResourceUsage ru) {
-        if (start.getPosition(gs.getPhysicalGameState())==targetpos||findPath(start,targetpos,gs,ru)!=null) return true;
-        return false;
+        return start.getPosition(gs.getPhysicalGameState()) == targetpos
+            || findPath(start, targetpos, gs, ru) != null;
     }
     
 
@@ -105,8 +105,8 @@ public class GreedyPathFinding extends PathFinding {
         int x = targetpos%gs.getPhysicalGameState().getWidth();
         int y = targetpos/gs.getPhysicalGameState().getWidth();
         int d = (x-start.getX())*(x-start.getX()) + (y-start.getY())*(y-start.getY());
-        if (d<=range*range||findPathToPositionInRange(start,targetpos,range,gs,ru)!=null) return true;
-        return false;
+        return d <= range * range
+            || findPathToPositionInRange(start, targetpos, range, gs, ru) != null;
     }
         
 }

--- a/src/ai/ahtn/domain/Binding.java
+++ b/src/ai/ahtn/domain/Binding.java
@@ -24,10 +24,7 @@ public class Binding {
     }
     
     public boolean equals(Object o) {
-        if (o instanceof Binding) {
-            Binding b = (Binding)o;
-            if (v.equals(b.v) && p.equals(b.p)) return true;
-        }
+        if (o instanceof Binding && v.equals(((Binding)o).v) && p.equals(((Binding)o).p)) return true;
         return false;
     }
 }

--- a/src/ai/ahtn/domain/Binding.java
+++ b/src/ai/ahtn/domain/Binding.java
@@ -24,7 +24,6 @@ public class Binding {
     }
     
     public boolean equals(Object o) {
-        if (o instanceof Binding && v.equals(((Binding)o).v) && p.equals(((Binding)o).p)) return true;
-        return false;
+        return o instanceof Binding && v.equals(((Binding) o).v) && p.equals(((Binding) o).p);
     }
 }

--- a/src/ai/ahtn/domain/Clause.java
+++ b/src/ai/ahtn/domain/Clause.java
@@ -42,41 +42,48 @@ public class Clause {
     
     public static Clause fromLispElement(LispElement e) throws Exception {
         LispElement head = e.children.get(0);
-        if (head.element.equals("and")) {
-            Clause c = new Clause();
-            c.type = CLAUSE_AND;
-            c.clauses = new Clause[e.children.size()-1];
-            for(int i = 0;i<e.children.size()-1;i++) {
-                c.clauses[i] = Clause.fromLispElement(e.children.get(i+1));
+        switch (head.element) {
+            case "and": {
+                ai.ahtn.domain.Clause c = new ai.ahtn.domain.Clause();
+                c.type = CLAUSE_AND;
+                c.clauses = new ai.ahtn.domain.Clause[e.children.size() - 1];
+                for (int i = 0; i < e.children.size() - 1; i++) {
+                    c.clauses[i] = ai.ahtn.domain.Clause.fromLispElement(e.children.get(i + 1));
+                }
+                return c;
             }
-            return c;            
-        } else if (head.element.equals("or")) {
-            Clause c = new Clause();
-            c.type = CLAUSE_OR;
-            c.clauses = new Clause[e.children.size()-1];
-            for(int i = 0;i<e.children.size()-1;i++) {
-                c.clauses[i] = Clause.fromLispElement(e.children.get(i+1));
+            case "or": {
+                ai.ahtn.domain.Clause c = new ai.ahtn.domain.Clause();
+                c.type = CLAUSE_OR;
+                c.clauses = new ai.ahtn.domain.Clause[e.children.size() - 1];
+                for (int i = 0; i < e.children.size() - 1; i++) {
+                    c.clauses[i] = ai.ahtn.domain.Clause.fromLispElement(e.children.get(i + 1));
+                }
+                return c;
             }
-            return c;            
-        } else if (head.element.equals("not")) {
-            Clause c = new Clause();
-            c.type = CLAUSE_NOT;
-            c.clauses = new Clause[1];
-            c.clauses[0] = Clause.fromLispElement(e.children.get(1));
-            return c;            
-        } else if (head.element.equals("true")) {
-            Clause c = new Clause();
-            c.type = CLAUSE_TRUE;
-            return c;
-        } else if (head.element.equals("false")) {
-            Clause c = new Clause();
-            c.type = CLAUSE_FALSE;
-            return c;
-        } else {
-            Clause c = new Clause();
-            c.type = CLAUSE_TERM;
-            c.term = Term.fromLispElement(e);
-            return c;
+            case "not": {
+                ai.ahtn.domain.Clause c = new ai.ahtn.domain.Clause();
+                c.type = CLAUSE_NOT;
+                c.clauses = new ai.ahtn.domain.Clause[1];
+                c.clauses[0] = ai.ahtn.domain.Clause.fromLispElement(e.children.get(1));
+                return c;
+            }
+            case "true": {
+                ai.ahtn.domain.Clause c = new ai.ahtn.domain.Clause();
+                c.type = CLAUSE_TRUE;
+                return c;
+            }
+            case "false": {
+                ai.ahtn.domain.Clause c = new ai.ahtn.domain.Clause();
+                c.type = CLAUSE_FALSE;
+                return c;
+            }
+            default: {
+                ai.ahtn.domain.Clause c = new ai.ahtn.domain.Clause();
+                c.type = CLAUSE_TERM;
+                c.term = ai.ahtn.domain.Term.fromLispElement(e);
+                return c;
+            }
         }
     }    
     

--- a/src/ai/ahtn/domain/IntegerConstant.java
+++ b/src/ai/ahtn/domain/IntegerConstant.java
@@ -50,8 +50,7 @@ public class IntegerConstant implements Parameter {
     }    
     
     public boolean equals(Object o) {
-        if (o instanceof IntegerConstant&&((IntegerConstant)o).value == value) return true;
-        return false;
+        return o instanceof IntegerConstant && ((IntegerConstant) o).value == value;
     }
     
 }

--- a/src/ai/ahtn/domain/IntegerConstant.java
+++ b/src/ai/ahtn/domain/IntegerConstant.java
@@ -50,9 +50,7 @@ public class IntegerConstant implements Parameter {
     }    
     
     public boolean equals(Object o) {
-        if (o instanceof IntegerConstant) {
-            if (((IntegerConstant)o).value == value) return true;
-        }
+        if (o instanceof IntegerConstant&&((IntegerConstant)o).value == value) return true;
         return false;
     }
     

--- a/src/ai/ahtn/domain/MethodDecomposition.java
+++ b/src/ai/ahtn/domain/MethodDecomposition.java
@@ -148,44 +148,53 @@ public class MethodDecomposition {
     
     public static MethodDecomposition fromLispElement(LispElement e) throws Exception {
         LispElement head = e.children.get(0);
-        if (head.element.equals(":condition")) {
-            MethodDecomposition d = new MethodDecomposition();
-            d.type = METHOD_CONDITION;
-            d.clause = Clause.fromLispElement(e.children.get(1));
-            return d;
-        } else if (head.element.equals(":!condition")) {
-            MethodDecomposition d = new MethodDecomposition();
-            d.type = METHOD_NON_BRANCHING_CONDITION;
-            d.clause = Clause.fromLispElement(e.children.get(1));
-            return d;
-        } else if (head.element.equals(":operator")) {
-            MethodDecomposition d = new MethodDecomposition();
-            d.type = METHOD_OPERATOR;
-            d.term = Term.fromLispElement(e.children.get(1));
-            return d;
-        } else if (head.element.equals(":method")) {
-            MethodDecomposition d = new MethodDecomposition();
-            d.type = METHOD_METHOD;
-            d.term = Term.fromLispElement(e.children.get(1));
-            return d;
-        } else if (head.element.equals(":sequence")) {
-            MethodDecomposition d = new MethodDecomposition();
-            d.type = METHOD_SEQUENCE;
-            d.subelements = new MethodDecomposition[e.children.size()-1];
-            for(int i = 0;i<e.children.size()-1;i++) {
-                d.subelements[i] = MethodDecomposition.fromLispElement(e.children.get(i+1));
+        switch (head.element) {
+            case ":condition": {
+                ai.ahtn.domain.MethodDecomposition d = new ai.ahtn.domain.MethodDecomposition();
+                d.type = METHOD_CONDITION;
+                d.clause = ai.ahtn.domain.Clause.fromLispElement(e.children.get(1));
+                return d;
             }
-            return d;
-        } else if (head.element.equals(":parallel")) {
-            MethodDecomposition d = new MethodDecomposition();
-            d.type = METHOD_PARALLEL;
-            d.subelements = new MethodDecomposition[e.children.size()-1];
-            for(int i = 0;i<e.children.size()-1;i++) {
-                d.subelements[i] = MethodDecomposition.fromLispElement(e.children.get(i+1));
+            case ":!condition": {
+                ai.ahtn.domain.MethodDecomposition d = new ai.ahtn.domain.MethodDecomposition();
+                d.type = METHOD_NON_BRANCHING_CONDITION;
+                d.clause = ai.ahtn.domain.Clause.fromLispElement(e.children.get(1));
+                return d;
             }
-            return d;
-        } else {
-            throw new Exception("unrecognized method decomposition!: " + head.element);
+            case ":operator": {
+                ai.ahtn.domain.MethodDecomposition d = new ai.ahtn.domain.MethodDecomposition();
+                d.type = METHOD_OPERATOR;
+                d.term = ai.ahtn.domain.Term.fromLispElement(e.children.get(1));
+                return d;
+            }
+            case ":method": {
+                ai.ahtn.domain.MethodDecomposition d = new ai.ahtn.domain.MethodDecomposition();
+                d.type = METHOD_METHOD;
+                d.term = ai.ahtn.domain.Term.fromLispElement(e.children.get(1));
+                return d;
+            }
+            case ":sequence": {
+                ai.ahtn.domain.MethodDecomposition d = new ai.ahtn.domain.MethodDecomposition();
+                d.type = METHOD_SEQUENCE;
+                d.subelements = new ai.ahtn.domain.MethodDecomposition[e.children.size() - 1];
+                for (int i = 0; i < e.children.size() - 1; i++) {
+                    d.subelements[i] = ai.ahtn.domain.MethodDecomposition
+                        .fromLispElement(e.children.get(i + 1));
+                }
+                return d;
+            }
+            case ":parallel": {
+                ai.ahtn.domain.MethodDecomposition d = new ai.ahtn.domain.MethodDecomposition();
+                d.type = METHOD_PARALLEL;
+                d.subelements = new ai.ahtn.domain.MethodDecomposition[e.children.size() - 1];
+                for (int i = 0; i < e.children.size() - 1; i++) {
+                    d.subelements[i] = ai.ahtn.domain.MethodDecomposition
+                        .fromLispElement(e.children.get(i + 1));
+                }
+                return d;
+            }
+            default:
+                throw new Exception("unrecognized method decomposition!: " + head.element);
         }
     }  
     

--- a/src/ai/ahtn/domain/PredefinedOperators.java
+++ b/src/ai/ahtn/domain/PredefinedOperators.java
@@ -44,8 +44,7 @@ public class PredefinedOperators {
                             int time = ((IntegerConstant)t.parameters[0]).value;
                             if (state.getOperatorExecutingState()==1) {
                                 // we submitted an action before, so, now we just have to wait the right amount of time:
-                                if ((gs.getTime()-state.getUpdatedTermCycle())>=time) return true;
-                                return false;
+                                return (gs.getTime() - state.getUpdatedTermCycle()) >= time;
                             } else {
                                 state.setOperatorExecutingState(1);
                                 return false;
@@ -104,8 +103,7 @@ public class PredefinedOperators {
                             if (u1==null) return true;
                             if (state.getOperatorExecutingState()==1) {
                                 // we submitted an action before, so, now we just have to wait:
-                                if (gs.getUnitAction(u1)==null) return true;
-                                return false;
+                                return gs.getUnitAction(u1) == null;
                             } else {
                                 if (pa==null) {
                                     pa = new PlayerAction();
@@ -130,8 +128,7 @@ public class PredefinedOperators {
                             if (gs.getUnitAction(u1)!=null) return false;
                             if (state.getOperatorExecutingState()==1) {
                                 // we submitted an action before, so, now we just have to wait:
-                                if (gs.getUnitAction(u1)==null) return true;
-                                return false;
+                                return gs.getUnitAction(u1) == null;
                             } else {
                                 int uID2 = ((IntegerConstant)t.parameters[1]).value;
                                 Unit u2 = gs.getUnit(uID2);
@@ -159,8 +156,7 @@ public class PredefinedOperators {
                             if (gs.getUnitAction(u1)!=null) return false;
                             if (state.getOperatorExecutingState()==1) {
                                 // we submitted an action before, so, now we just have to wait:
-                                if (gs.getUnitAction(u1)==null) return true;
-                                return false;
+                                return gs.getUnitAction(u1) == null;
                             } else {
                                 int uID2 = ((IntegerConstant)t.parameters[1]).value;
                                 Unit u2 = gs.getUnit(uID2);
@@ -194,8 +190,7 @@ public class PredefinedOperators {
                             if (gs.getUnitAction(u1)!=null) return false;
                             if (state.getOperatorExecutingState()==1) {
                                 // we submitted an action before, so, now we just have to wait:
-                                if (gs.getUnitAction(u1)==null) return true;
-                                return false;
+                                return gs.getUnitAction(u1) == null;
                             } else {
                                 int uID2 = ((IntegerConstant)t.parameters[1]).value;
                                 Unit u2 = gs.getUnit(uID2);
@@ -236,8 +231,7 @@ public class PredefinedOperators {
                             if (state.getOperatorExecutingState()==1) {
 //                                System.out.println("PRODUCE already executing for"  + uID1 + "!");
                                 // we submitted an action before, so, now we just have to wait:
-                                if (gs.getUnitAction(u1)==null) return true;
-                                return false;
+                                return gs.getUnitAction(u1) == null;
                             } else {
 //                                System.out.println("PRODUCE working fine for "  + uID1 + "!");
                                 int direction = ((IntegerConstant)t.parameters[1]).value;

--- a/src/ai/ahtn/domain/Symbol.java
+++ b/src/ai/ahtn/domain/Symbol.java
@@ -87,26 +87,22 @@ public class Symbol {
     public boolean equals(String str) {
         if (mSym == null) {
             return str == null;
-        } else {
-            if (str == null) {
-                return false;
-            }
-            return (mSym.toString().equals(str));
         }
+        if (str == null) {
+            return false;
+        }
+        return (mSym.toString().equals(str));
     }
     
 
     public boolean equals(StringBuffer str) {
         if (mSym == null) {
             return str == null;
-        } else {
-            if (str == null) {
-                return false;
-            }
-			// System.out.println("Symbol.equals: '" + m_sym + "' == '" + str + "'? -> " +
-            // m_sym.toString().equals(str.toString()));
-            return (mSym.toString().equals(str.toString()));
         }
+        if (str == null) {
+            return false;
+        }
+        return (mSym.toString().equals(str.toString()));
     }
     
 

--- a/src/ai/ahtn/domain/Symbol.java
+++ b/src/ai/ahtn/domain/Symbol.java
@@ -86,10 +86,7 @@ public class Symbol {
     
     public boolean equals(String str) {
         if (mSym == null) {
-            if (str == null) {
-                return true;
-            }
-            return false;
+            return str == null;
         } else {
             if (str == null) {
                 return false;
@@ -101,10 +98,7 @@ public class Symbol {
 
     public boolean equals(StringBuffer str) {
         if (mSym == null) {
-            if (str == null) {
-                return true;
-            }
-            return false;
+            return str == null;
         } else {
             if (str == null) {
                 return false;

--- a/src/ai/ahtn/planner/AdversarialBoundedDepthPlannerAlphaBeta.java
+++ b/src/ai/ahtn/planner/AdversarialBoundedDepthPlannerAlphaBeta.java
@@ -361,7 +361,7 @@ public class AdversarialBoundedDepthPlannerAlphaBeta {
                 int nPlayoutsleft = maxPlayouts - nPlayouts;
                 if (maxPlayouts<0 || nPlayoutsleft>nPlayoutsUSedLastTime) {
                     if (DEBUG>=1) System.out.println("last time we used " + nPlayoutsUSedLastTime + ", and there are " + nPlayoutsleft + " left, trying one more depth!");
-                    best = planner.getBestPlan(timeLimit, maxPlayouts, (bestLastDepth==null ? true:false));                
+                    best = planner.getBestPlan(timeLimit, maxPlayouts, (bestLastDepth == null));
                 } else {
                     if (DEBUG>=1) System.out.println("last time we used " + nPlayoutsUSedLastTime + ", and there are only " + nPlayoutsleft + " left..., canceling search");
                 }

--- a/src/ai/ahtn/planner/AdversarialChoicePoint.java
+++ b/src/ai/ahtn/planner/AdversarialChoicePoint.java
@@ -372,26 +372,14 @@ public class AdversarialChoicePoint {
                 }
                 break;
         }
-        
-        // alpha-beta prunning:
-        if (minimaxType==0) {
-            // max node:
+
+        // alpha-beta pruning
+        if (minimaxType==0)
             alpha = Math.max(alpha, f);
-//            System.out.println(alpha + " <= " + beta);
-            if (beta<=alpha) {
-                // beta cutoff:
-                return true;
-            }
-        } else if (minimaxType==1) {
-            // min node:
+        else if (minimaxType==1)
             beta = Math.min(beta, f);
-//            System.out.println(alpha + " <= " + beta);
-            if (beta<=alpha) {
-                // alpha cutoff:
-                return true;
-            }
-        }       
-        return false;
+
+        return beta <= alpha;
     }
     
     

--- a/src/ai/evaluation/LanchesterEvaluationFunction.java
+++ b/src/ai/evaluation/LanchesterEvaluationFunction.java
@@ -35,11 +35,9 @@ public class LanchesterEvaluationFunction extends EvaluationFunction {
     public float base_score(int player, GameState gs) {
     	PhysicalGameState pgs = gs.getPhysicalGameState();
     	int index = 0;
-    	switch(pgs.getWidth()){
-    	case 128:
-    		index = 1;
-    		break;
-    	}
+        if (pgs.getWidth() == 128) {
+            index = 1;
+        }
 
     	float score = 0.0f;
     	float score_buildings = 0.0f;

--- a/src/ai/montecarlo/lsi/LSI.java
+++ b/src/ai/montecarlo/lsi/LSI.java
@@ -158,14 +158,11 @@ public class LSI extends AIWithComputationBudget {
         }
 
         // pre-relaxation (e.g., --LSI)
-        switch (relaxationType) {
-            case PRE_RANDOM:
-                List<Integer> indices = getRelaxedAgentIndicesRandom(unitActionTable);
-                for (int index : indices) {
-                    unitActionTable.remove(index);
-                }
-                break;
-            default:
+        if (relaxationType == ai.montecarlo.lsi.LSI.RelaxationType.PRE_RANDOM) {
+            java.util.List<Integer> indices = getRelaxedAgentIndicesRandom(unitActionTable);
+            for (int index : indices) {
+                unitActionTable.remove(index);
+            }
         }
 
         PlayerAction playerAction = new PlayerAction();

--- a/src/ai/montecarlo/lsi/LSI.java
+++ b/src/ai/montecarlo/lsi/LSI.java
@@ -284,7 +284,7 @@ public class LSI extends AIWithComputationBudget {
 
                                     @Override
                                     public int compare(Pair<Integer, Double> p1, Pair<Integer, Double> p2) {
-                                        return p1.m_b > p2.m_b ? 1 : (p1.m_b < p2.m_b ? -1 : 0);
+                                        return p1.m_b.compareTo(p2.m_b);
                                     }
 
                                 });
@@ -294,7 +294,7 @@ public class LSI extends AIWithComputationBudget {
 
                                     @Override
                                     public int compare(Pair<Integer, Double> p1, Pair<Integer, Double> p2) {
-                                        return p1.m_b < p2.m_b ? 1 : (p1.m_b > p2.m_b ? -1 : 0);
+                                        return p2.m_b.compareTo(p1.m_b);
                                     }
 
                                 });
@@ -309,7 +309,7 @@ public class LSI extends AIWithComputationBudget {
 
                             @Override
                             public int compare(Pair<Integer, Double> p1, Pair<Integer, Double> p2) {
-                                return p1.m_a < p2.m_a ? 1 : (p1.m_a > p2.m_a ? -1 : 0);
+                                return p2.m_a.compareTo(p1.m_a);
                             }
 
                         });
@@ -697,7 +697,7 @@ public class LSI extends AIWithComputationBudget {
                 public int compare(Pair<Integer, Double> p1, Pair<Integer, Double> p2) {
                     double eval1 = p1.m_b;
                     double eval2 = p2.m_b;
-                    return eval1 > eval2 ? 1 : (eval1 < eval2 ? -1 : 0);
+                    return Double.compare(eval1, eval2);
                 }
 
             });
@@ -709,7 +709,7 @@ public class LSI extends AIWithComputationBudget {
                 public int compare(Pair<Integer, Double> p1, Pair<Integer, Double> p2) {
                     double eval1 = p1.m_a;
                     double eval2 = p2.m_a;
-                    return eval1 < eval2 ? 1 : (eval1 > eval2 ? -1 : 0);
+                    return Double.compare(eval2, eval1);
                 }
 
             });
@@ -842,7 +842,7 @@ public class LSI extends AIWithComputationBudget {
                                    Entry<PlayerAction, Pair<Double, Integer>> e2) {
                     double eval1 = e1.getValue().m_a / e1.getValue().m_b;
                     double eval2 = e2.getValue().m_a / e2.getValue().m_b;
-                    return eval1 < eval2 ? 1 : (eval1 > eval2 ? -1 : 0);
+                    return Double.compare(eval2, eval1);
                 }
 
             });
@@ -918,7 +918,7 @@ public class LSI extends AIWithComputationBudget {
                 public int compare(Pair<PlayerAction, Pair<Double, Integer>> p1, Pair<PlayerAction, Pair<Double, Integer>> p2) {
                     double eval1 = p1.m_b.m_a / p1.m_b.m_b;
                     double eval2 = p2.m_b.m_a / p2.m_b.m_b;
-                    return eval1 < eval2 ? 1 : (eval1 > eval2 ? -1 : 0);
+                    return Double.compare(eval2, eval1);
 
                 }
 

--- a/src/ai/montecarlo/lsi/Sampling.java
+++ b/src/ai/montecarlo/lsi/Sampling.java
@@ -101,7 +101,7 @@ public class Sampling {
                 ent_list.sort(new Comparator<>() {
                     @Override
                     public int compare(Pair<Integer, Double> p1, Pair<Integer, Double> p2) {
-                        return p1.m_b > p2.m_b ? 1 : (p1.m_b < p2.m_b ? -1 : 0);
+                        return p1.m_b.compareTo(p2.m_b);
                     }
                 });
                 break;
@@ -324,7 +324,7 @@ public class Sampling {
             public int compare(Pair<PlayerAction, Pair<Double, Integer>> p1, Pair<PlayerAction, Pair<Double, Integer>> p2) {
                 double eval1 = p1.m_b.m_a / p1.m_b.m_b;
                 double eval2 = p2.m_b.m_a / p2.m_b.m_b;
-                return eval1 < eval2 ? 1 : (eval1 > eval2 ? -1 : 0);
+                return Double.compare(eval2, eval1);
 
             }
 
@@ -344,7 +344,7 @@ public class Sampling {
 
             @Override
             public int compare(Pair<PlayerAction, Double> p1, Pair<PlayerAction, Double> p2) {
-                return p1.m_b < p2.m_b ? 1 : (p1.m_b > p2.m_b ? -1 : 0);
+                return p2.m_b.compareTo(p1.m_b);
             }
 
         });
@@ -363,7 +363,7 @@ public class Sampling {
 
             @Override
             public int compare(Pair<PlayerAction, Double> p1, Pair<PlayerAction, Double> p2) {
-                return p1.m_b < p2.m_b ? 1 : (p1.m_b > p2.m_b ? -1 : 0);
+                return p2.m_b.compareTo(p1.m_b);
             }
 
         });

--- a/src/ai/puppet/PuppetBase.java
+++ b/src/ai/puppet/PuppetBase.java
@@ -86,11 +86,7 @@ public abstract class PuppetBase extends AIWithComputationBudget {
 		PLAN_PLAYOUTS=max_plan_playouts;
 		STEP_PLAYOUT_TIME=step_playout_time;
 
-		if(max_plan_time>=0||max_plan_playouts>=0){
-			PLAN=true;
-		}else{
-			PLAN=false;
-		}
+        PLAN= max_plan_time >= 0 || max_plan_playouts >= 0;
 		this.script=script;
 		eval=evaluation;
 		lastSearchFrame=-1;

--- a/src/ai/puppet/SingleChoiceConfigurableScript.java
+++ b/src/ai/puppet/SingleChoiceConfigurableScript.java
@@ -47,12 +47,9 @@ public class SingleChoiceConfigurableScript extends ConfigurableScript<SingleCho
 			opts[i]=i;
 		}
 		for(SingleChoice c:choicePointValues){
-			switch(c){
-			case SINGLE: 
-				choicePoints.put(c, new Options(c.ordinal(),opts));
-				break;
-
-			}
+            if (c == ai.puppet.SingleChoice.SINGLE) {
+                choicePoints.put(c, new ai.puppet.ConfigurableScript.Options(c.ordinal(), opts));
+            }
 		}
 	}
 

--- a/src/gui/PGSMouseListener.java
+++ b/src/gui/PGSMouseListener.java
@@ -358,8 +358,6 @@ public class PGSMouseListener implements MouseListener, MouseMotionListener, Key
                 
         Rectangle r = frame.panel.getBounds();
         // if mouse was outside of playing area, return:
-        if (x<r.x || x>=r.x+r.width ||
-            y<r.y || y>=r.y+r.height) return false;
-        return true;        
+        return x >= r.x && x < r.x + r.width && y >= r.y && y < r.y + r.height;
     }
 }

--- a/src/rts/GameState.java
+++ b/src/rts/GameState.java
@@ -426,10 +426,8 @@ public class GameState {
                 empty.r.merge(ru);
             }
         }
-        
-        if (ua.resourceUsage(u, pgs).consistentWith(empty.getResourceUsage(), this)) return true;
-        
-        return false;
+
+        return ua.resourceUsage(u, pgs).consistentWith(empty.getResourceUsage(), this);
     }
         
     

--- a/src/rts/PhysicalGameState.java
+++ b/src/rts/PhysicalGameState.java
@@ -346,10 +346,7 @@ public class PhysicalGameState {
             }
         }
 
-        if (winner != -1) {
-            return true;
-        }
-        return false;
+        return winner != -1;
     }
 
     /* (non-Javadoc)

--- a/src/rts/UnitAction.java
+++ b/src/rts/UnitAction.java
@@ -5,9 +5,10 @@ import com.eclipsesource.json.JsonObject;
 import java.io.Writer;
 import java.util.Objects;
 import java.util.Random;
-
 import org.jdom.Element;
-import rts.units.*;
+import rts.units.Unit;
+import rts.units.UnitType;
+import rts.units.UnitTypeTable;
 import util.XMLWriter;
 
 /**
@@ -192,22 +193,14 @@ public class UnitAction {
 
         if (a.type != type) {
             return false;
-        }
-        if (type == TYPE_NONE || type == TYPE_MOVE || type == TYPE_HARVEST || type == TYPE_RETURN) {
-            if (a.parameter != parameter) {
-                return false;
-            }
+        } else if (type == TYPE_NONE || type == TYPE_MOVE || type == TYPE_HARVEST
+            || type == TYPE_RETURN) {
+            return a.parameter == parameter;
         } else if (type == TYPE_ATTACK_LOCATION) {
-            if (a.x != x || a.y != y) {
-                return false;
-            }
+            return a.x == x && a.y == y;
         } else {
-            if (a.parameter != parameter || a.unitType != unitType) {
-                return false;
-            }
+            return a.parameter == parameter && a.unitType == unitType;
         }
-
-        return true;
     }
 
     @Override


### PR DESCRIPTION
This PR is another part of #54, specifically:
> simplified boolean expressions in if, return and switch statements

A prevalent structure I found in the code is the following
```java
if(x) return true;
return false
```
which can be simplified to
```java
return x;
```
An extension of that is
```java
if(x) return true;
if(y) return true;
if(z) return true;
return false
```
which can be simplified to:
```java
return x || y || z;
```
Refactoring of this nature was done in the first 4 commits.

The 5th commit replaced `switch` statements which had only a single `case` clause (I know right) into an `if` statement.

In the 6th commit, I found places where the `compare()` method for numbers was performed manually and replaced that with the Java `compare()` method.

In the 7th commit, I found two instances of chained `if` statements which evaluated the value of the same variable and transformed them into a single `switch` statement.

In the 8th commit, I just removed a couple of redundant `else` statements.

There were 2 or 3 files which (I believe) had different line endings to the ones configured in my machine, so git is flagging the whole file as changed, but I assure that no further changes were performed.