### PR TITLE
Create options to compress terrain and only send constant state data during pre-game analysis

### DIFF
--- a/resources/config.properties
+++ b/resources/config.properties
@@ -11,6 +11,8 @@ launch_mode=STANDALONE
 # 1 = XML
 # 2 = JSON
 # serialization_type=2
+constants_in_state=true
+compress_terrain=false
 
 # MAP
 map_location=maps/16x16/basesWorkers16x16.xml

--- a/resources/config.properties
+++ b/resources/config.properties
@@ -11,7 +11,12 @@ launch_mode=STANDALONE
 # 1 = XML
 # 2 = JSON
 # serialization_type=2
+
+# true if terrain, width and height are to be passed in every single state
+# false to pass that constant data only in pre-game analysis
 constants_in_state=true
+# true to compress terrain information using run-length encoding, where
+# 0 = A and 1 = B, false to send the full binary data
 compress_terrain=false
 
 # MAP

--- a/src/ai/socket/SocketAI.java
+++ b/src/ai/socket/SocketAI.java
@@ -216,43 +216,22 @@ public class SocketAI extends AIWithComputationBudget {
             throw new Exception("Communication language " + communication_language + " not supported!");
         }        
     }
-    
 
     @Override
-    public void preGameAnalysis(GameState gs, long milliseconds) throws Exception 
-    {
-        // send the game state:
-        out_pipe.append("preGameAnalysis ").append(String.valueOf(milliseconds)).append("\n");
-        switch (communication_language) {
-            case LANGUAGE_XML:
-                XMLWriter w = new XMLWriter(out_pipe, " ");
-                gs.toxml(w);
-                w.flush();
-                out_pipe.append("\n");
-                out_pipe.flush();
-                // wait for ack:
-                in_pipe.readLine();
-                break;
-                
-            case LANGUAGE_JSON:
-                gs.toJSON(out_pipe);
-                out_pipe.append("\n");
-                out_pipe.flush();
-                // wait for ack:
-                in_pipe.readLine();
-                break;
-                
-            default:
-                throw new Exception("Communication language " + communication_language + " not supported!");        
-        }
+    public void preGameAnalysis(GameState gs, long milliseconds) throws Exception {
+        preGameAnalysis(gs, milliseconds, null);
     }
 
-    
     @Override
-    public void preGameAnalysis(GameState gs, long milliseconds, String readWriteFolder) throws Exception 
-    {
-        // send the game state:
-        out_pipe.append("preGameAnalysis ").append(String.valueOf(milliseconds)).append("  \"").append(readWriteFolder).append("\"\n");
+    public void preGameAnalysis(GameState gs, long milliseconds, String readWriteFolder)
+        throws Exception {
+        out_pipe.append("preGameAnalysis ").append(String.valueOf(milliseconds));
+        if (readWriteFolder != null) {
+            out_pipe.append("  \"").append(readWriteFolder).append("\"");
+        }
+
+        out_pipe.append("\n");
+
         switch (communication_language) {
             case LANGUAGE_XML:
                 XMLWriter w = new XMLWriter(out_pipe, " ");

--- a/src/ai/socket/SocketAI.java
+++ b/src/ai/socket/SocketAI.java
@@ -134,7 +134,7 @@ public class SocketAI extends AIWithComputationBudget {
             out_pipe.append("budget ").append(String.valueOf(TIME_BUDGET)).append(" ").append(String.valueOf(ITERATIONS_BUDGET)).append("\n");
             out_pipe.flush();
 
-            if (DEBUG>=1) System.out.println("SocketAI: budgetd sent, waiting for ack");
+            if (DEBUG>=1) System.out.println("SocketAI: budget sent, waiting for ack");
             
             // wait for ack:
             in_pipe.readLine();

--- a/src/ai/socket/SocketAI.java
+++ b/src/ai/socket/SocketAI.java
@@ -178,7 +178,7 @@ public class SocketAI extends AIWithComputationBudget {
         out_pipe.append("getAction ").append(String.valueOf(player)).append("\n");
         if (communication_language == LANGUAGE_XML) {
             XMLWriter w = new XMLWriter(out_pipe, " ");
-            gs.toxml(w);
+            gs.toxml(w, includeConstants, compressTerrain);
             w.getWriter().append("\n");
             w.flush();
 
@@ -190,13 +190,16 @@ public class SocketAI extends AIWithComputationBudget {
                 
             // parse the action:
             String actionString = in_pipe.readLine();
-            if (DEBUG>=1) System.out.println("action received from server: " + actionString);
-            Element action_e = new SAXBuilder().build(new StringReader(actionString)).getRootElement();
+            if (DEBUG >= 1) {
+                System.out.println("action received from server: " + actionString);
+            }
+            Element action_e = new SAXBuilder().build(new StringReader(actionString))
+                .getRootElement();
             PlayerAction pa = PlayerAction.fromXML(action_e, gs, utt);
             pa.fillWithNones(gs, player, 10);
             return pa;
         } else if (communication_language == LANGUAGE_JSON) {
-            gs.toJSON(out_pipe);
+            gs.toJSON(out_pipe, includeConstants, compressTerrain);
             out_pipe.append("\n");
             out_pipe.flush();
             

--- a/src/ai/socket/SocketAI.java
+++ b/src/ai/socket/SocketAI.java
@@ -31,8 +31,10 @@ public class SocketAI extends AIWithComputationBudget {
     
     public static final int LANGUAGE_XML = 1;
     public static final int LANGUAGE_JSON = 2;
+
+    private boolean includeConstants = true, compressTerrain = false;
     
-    UnitTypeTable utt = null;
+    UnitTypeTable utt;
             
     int communication_language = LANGUAGE_XML;
     String serverAddress = "127.0.0.1";
@@ -60,15 +62,18 @@ public class SocketAI extends AIWithComputationBudget {
         utt = a_utt;
         try {
             connectToServer();
-        }catch(Exception e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
     }
 
-    private SocketAI(int mt, int mi, UnitTypeTable a_utt, int a_language, Socket socket) {
+    private SocketAI(int mt, int mi, UnitTypeTable a_utt, int a_language,
+        boolean includeConstantsInState, boolean compressTerrain, Socket socket) {
         super(mt, mi);
         communication_language = a_language;
         utt = a_utt;
+        this.includeConstants = includeConstantsInState;
+        this.compressTerrain = compressTerrain;
         try {
             this.socket = socket;
             in_pipe = new BufferedReader(new InputStreamReader(socket.getInputStream()));
@@ -78,23 +83,31 @@ public class SocketAI extends AIWithComputationBudget {
             while(!in_pipe.ready());
             while(in_pipe.ready()) in_pipe.readLine();
 
-            if (DEBUG>=1) System.out.println("SocketAI: welcome message received");
+            if (DEBUG >= 1) {
+                System.out.println("SocketAI: welcome message received");
+            }
             reset();
-        }catch(Exception e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
     }
 
     /**
      * Creates a SocketAI from an existing socket.
-     * @param mt The time budget in milliseconds.
-     * @param mi The iterations budget in milliseconds
-     * @param a_utt The unit type table.
-     * @param a_language The communication layer to use.
-     * @param socket The socket the ai will communicate over.
+     *
+     * @param mt                      The time budget in milliseconds.
+     * @param mi                      The iterations budget in milliseconds
+     * @param a_utt                   The unit type table.
+     * @param a_language              The communication layer to use.
+     * @param includeConstantsInState
+     * @param compressTerrain
+     * @param socket                  The socket the ai will communicate over.
      */
-    public static SocketAI createFromExistingSocket(int mt, int mi, UnitTypeTable a_utt, int a_language, Socket socket) {
-        return new SocketAI(mt, mi, a_utt, a_language, socket);
+    public static SocketAI createFromExistingSocket(int mt, int mi, rts.units.UnitTypeTable a_utt,
+        int a_language, boolean includeConstantsInState, boolean compressTerrain,
+        java.net.Socket socket) {
+        return new SocketAI(mt, mi, a_utt, a_language, includeConstantsInState, compressTerrain,
+            socket);
     }
     
     

--- a/src/rts/GameSettings.java
+++ b/src/rts/GameSettings.java
@@ -29,16 +29,17 @@ public class GameSettings {
     private boolean partiallyObservable = false;
     private int uttVersion = 1;
     private int conflictPolicy = 1;
-    
+
+    private boolean includeConstantsInState = true, compressTerrain = false;
+
     // Opponents:
     private String AI1 = "";
     private String AI2 = "";
-    
 
-    public GameSettings( LaunchMode launchMode, String serverAddress, int serverPort, 
-                          int serializationType, String mapLocation, int maxCycles, 
-                          boolean partiallyObservable, int uttVersion, int confictPolicy, 
-                          String AI1, String AI2) {
+    public GameSettings(LaunchMode launchMode, String serverAddress, int serverPort,
+        int serializationType, String mapLocation, int maxCycles, boolean partiallyObservable,
+        int uttVersion, int confictPolicy, boolean includeConstantsInState, boolean compressTerrain,
+        String AI1, String AI2) {
         this.launchMode = launchMode;
         this.serverAddress = serverAddress;
         this.serverPort = serverPort;
@@ -48,6 +49,8 @@ public class GameSettings {
         this.partiallyObservable = partiallyObservable;
         this.uttVersion = uttVersion;
         this.conflictPolicy = confictPolicy;
+        this.includeConstantsInState = includeConstantsInState;
+        this.compressTerrain = compressTerrain;
         this.AI1 = AI1;
         this.AI2 = AI2;
     }
@@ -94,6 +97,14 @@ public class GameSettings {
 
     public String getAI2() {
         return AI2;
+    }
+
+    public boolean isIncludeConstantsInState() {
+        return includeConstantsInState;
+    }
+
+    public boolean isCompressTerrain() {
+        return compressTerrain;
     }
 
     /**
@@ -203,13 +214,14 @@ public class GameSettings {
         int uttVersion = readIntegerProperty(prop, "UTT_version", 2);
         int conflictPolicy = readIntegerProperty(prop, "conflict_policy", 1);
         LaunchMode launchMode = LaunchMode.valueOf(prop.getProperty("launch_mode"));
+        boolean includeConstantsInState = Boolean.parseBoolean(prop.getProperty("constants_in_state"));
+        boolean compressTerrain = Boolean.parseBoolean(prop.getProperty("compress_terrain"));
         String AI1 = prop.getProperty("AI1");
         String AI2 = prop.getProperty("AI2");
 
-        return new GameSettings(launchMode, serverAddress, serverPort,
-                                serializationType, mapLocation, maxCycles,
-                                partiallyObservable, uttVersion, conflictPolicy, 
-                                AI1, AI2);
+        return new GameSettings(launchMode, serverAddress, serverPort, serializationType,
+            mapLocation, maxCycles, partiallyObservable, uttVersion, conflictPolicy,
+            includeConstantsInState, compressTerrain, AI1, AI2);
     }
     
     

--- a/src/rts/GameState.java
+++ b/src/rts/GameState.java
@@ -4,18 +4,19 @@ import com.eclipsesource.json.Json;
 import com.eclipsesource.json.JsonArray;
 import com.eclipsesource.json.JsonObject;
 import com.eclipsesource.json.JsonValue;
-
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Writer;
-import java.util.*;
-
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Random;
 import org.jdom.Document;
 import org.jdom.Element;
 import org.jdom.JDOMException;
 import org.jdom.input.SAXBuilder;
-
 import rts.units.Unit;
 import rts.units.UnitType;
 import rts.units.UnitTypeTable;
@@ -728,25 +729,35 @@ public class GameState {
         return tmp.toString();
     }
 
-    
     /**
      * Writes a XML representation of this state into a XMLWriter
+     *
      * @param w
      */
     public void toxml(XMLWriter w) {
-        w.tagWithAttributes(this.getClass().getName(),"time=\"" + time + "\"");
-        pgs.toxml(w);
+        toxml(w, true, false);
+    }
+
+    /**
+     * Writes a XML representation of this state into a XMLWriter
+     *
+     * @param w
+     */
+    public void toxml(XMLWriter w, boolean includeConstants, boolean compressTerrain) {
+        w.tagWithAttributes(this.getClass().getName(), "time=\"" + time + "\"");
+        pgs.toxml(w, includeConstants, compressTerrain);
         w.tag("actions");
-        for(Unit u:unitActions.keySet()) {
+        for (Unit u : unitActions.keySet()) {
             UnitActionAssignment uaa = unitActions.get(u);
-            w.tagWithAttributes("unitAction","ID=\""+uaa.unit.getID()+"\" time=\""+uaa.time+"\"");
+            w.tagWithAttributes("unitAction",
+                "ID=\"" + uaa.unit.getID() + "\" time=\"" + uaa.time + "\"");
             uaa.action.toxml(w);
             w.tag("/unitAction");
         }
         w.tag("/actions");
         w.tag("/" + this.getClass().getName());
     }
-    
+
     /**
      * Dumps this state to a XML file.
      * It can be reconstructed later (e.g. with {@link #fromXML(String, UnitTypeTable)}
@@ -762,23 +773,36 @@ public class GameState {
 			e.printStackTrace();
 		}
     }
-    
+
     /**
      * Writes a JSON representation of this state
+     *
      * @param w
      * @throws Exception
      */
     public void toJSON(Writer w) throws Exception {
+        toJSON(w, true, false);
+    }
+
+    /**
+     * Writes a JSON representation of this state
+     *
+     * @param w
+     * @throws Exception
+     */
+    public void toJSON(Writer w, boolean includeConstants, boolean compressTerrain) throws Exception {
         w.write("{");
         w.write("\"time\":" + time + ",\"pgs\":");
-        pgs.toJSON(w);
+        pgs.toJSON(w, includeConstants, compressTerrain);
         w.write(",\"actions\":[");
         boolean first = true;
-        for(Unit u:unitActions.keySet()) {
-            if (!first) w.write(",");
+        for (Unit u : unitActions.keySet()) {
+            if (!first) {
+                w.write(",");
+            }
             first = false;
             UnitActionAssignment uaa = unitActions.get(u);
-            w.write("{\"ID\":" + uaa.unit.getID() + ", \"time\":"+uaa.time+", \"action\":");
+            w.write("{\"ID\":" + uaa.unit.getID() + ", \"time\":" + uaa.time + ", \"action\":");
             uaa.action.toJSON(w);
             w.write("}");
         }

--- a/src/rts/PhysicalGameState.java
+++ b/src/rts/PhysicalGameState.java
@@ -8,17 +8,16 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Writer;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Arrays;
-
-import rts.units.Unit;
+import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
-import util.XMLWriter;
 import org.jdom.Element;
 import org.jdom.JDOMException;
 import org.jdom.input.SAXBuilder;
+import rts.units.Unit;
 import rts.units.UnitTypeTable;
+import util.XMLWriter;
 
 /**
  * The physical game state (the actual 'map') of a microRTS game
@@ -578,21 +577,24 @@ public class PhysicalGameState {
      * @param w
      */
     public void toxml(XMLWriter w) {
-        toxml(w, false);
+        toxml(w, true, false);
     }
 
-    public void toxml(XMLWriter w, boolean compressTerrain) {
-        w.tagWithAttributes(this.getClass().getName(),
-            "width=\"" + width + "\" height=\"" + height + "\"");
-
-        if (compressTerrain) {
-            w.tag("terrain", compressTerrain());
+    public void toxml(XMLWriter w, boolean includeConstants, boolean compressTerrain) {
+        if (!includeConstants) {
+            w.tag(this.getClass().getName());
         } else {
-            StringBuilder tmp = new StringBuilder(height * width);
-            for (int i = 0; i < height * width; i++) {
-                tmp.append(terrain[i]);
+            w.tagWithAttributes(this.getClass().getName(),
+                "width=\"" + width + "\" height=\"" + height + "\"");
+            if (compressTerrain) {
+                w.tag("terrain", compressTerrain());
+            } else {
+                StringBuilder tmp = new StringBuilder(height * width);
+                for (int i = 0; i < height * width; i++) {
+                    tmp.append(terrain[i]);
+                }
+                w.tag("terrain", tmp.toString());
             }
-            w.tag("terrain", tmp.toString());
         }
 
         w.tag("players");
@@ -615,23 +617,25 @@ public class PhysicalGameState {
      * @throws Exception
      */
     public void toJSON(Writer w) throws Exception {
-        toJSON(w, false);
+        toJSON(w, true, false);
     }
 
-    public void toJSON(Writer w, boolean compressTerrain) throws Exception {
+    public void toJSON(Writer w, boolean includeConstants, boolean compressTerrain) throws Exception {
         w.write("{");
-        w.write("\"width\":" + width + ",\"height\":" + height + ",");
 
-        if (compressTerrain) {
-            w.write("\"terrain\":\"" + compressTerrain());
-        } else {
-            w.write("\"terrain\":\"");
-            for (int i = 0; i < height * width; i++) {
-                w.write("" + terrain[i]);
+        if (includeConstants) {
+            w.write("\"width\":" + width + ",\"height\":" + height+",");
+            if (compressTerrain) {
+                w.write("\"terrain\":\"" + compressTerrain());
+            } else {
+                w.write("\"terrain\":\"");
+                for (int i = 0; i < height * width; i++) {
+                    w.write("" + terrain[i]);
+                }
             }
+            w.write("\",");
         }
 
-        w.write("\",");
         w.write("\"players\":[");
         for (int i = 0; i < players.size(); i++) {
             players.get(i).toJSON(w);

--- a/src/rts/PhysicalGameState.java
+++ b/src/rts/PhysicalGameState.java
@@ -522,6 +522,29 @@ public class PhysicalGameState {
         w.tag("/" + this.getClass().getName());
     }
 
+    String compressTerrain(int[] terrain, int size){
+        StringBuilder strTerrain = new StringBuilder();
+
+        int occurrences = 1;
+        for (int i = 1; i < size; i++) {
+            if(terrain[i]==terrain[i-1])
+                occurrences++;
+            else {
+                strTerrain.append(terrain[i - 1]==0?'A':'B');
+
+                if(occurrences>1)
+                    strTerrain.append(occurrences);
+
+                occurrences=1;
+            }
+        }
+
+        if(occurrences>1)
+            strTerrain.append(terrain[terrain.length-1]==0?'A':'B').append(occurrences);
+
+        return strTerrain.toString();
+    }
+
     /**
      * Writes a JSON representation of this map
      *
@@ -531,10 +554,11 @@ public class PhysicalGameState {
     public void toJSON(Writer w) throws Exception {
         w.write("{");
         w.write("\"width\":" + width + ",\"height\":" + height + ",");
-        w.write("\"terrain\":\"");
-        for (int i = 0; i < height * width; i++) {
-            w.write("" + terrain[i]);
-        }
+        w.write("\"terrain\":\""+compressTerrain(terrain,width*height));
+
+//        for (int i = 0; i < height * width; i++) {
+//            w.write("" + terrain[i]);
+//        }
         w.write("\",");
         w.write("\"players\":[");
         for (int i = 0; i < players.size(); i++) {

--- a/src/rts/PhysicalGameState.java
+++ b/src/rts/PhysicalGameState.java
@@ -497,6 +497,87 @@ public class PhysicalGameState {
     }
 
     /**
+     * Create a compressed String representation of the terrain vector.
+     * <p>
+     *     The terrain vector is an array of Integers, whose elements only assume 0 and 1 as
+     *     possible values. This method compresses the terrain vector by counting the number of
+     *     consecutive occurrences of a value and appending this to a String.
+     *     Since 0 and 1 may appear in the counter, 0 is replaced by A and 1 is replaced by B.
+     * </p>
+     * <p>
+     *     For example, the String <code>00000011110000000000</code> is transformed into
+     *     <code>A6B4A10</code>.
+     * </p>
+     * <p>
+     *     This method is useful when the terrain composes part of a message, to be shared between
+     *     client and server.
+     * </p>
+     *
+     * @return compressed String representation of the terrain vector
+     */
+    private String compressTerrain() {
+        StringBuilder strTerrain = new StringBuilder();
+
+        int occurrences = 1;
+        for (int i = 1; i < height * width; i++) {
+            if (terrain[i] == terrain[i - 1]) {
+                occurrences++;
+            } else {
+                strTerrain.append(terrain[i - 1] == 0 ? 'A' : 'B');
+
+                if (occurrences > 1) {
+                    strTerrain.append(occurrences);
+                }
+
+                occurrences = 1;
+            }
+        }
+
+        if(occurrences>1)
+            strTerrain.append(terrain[terrain.length-1]==0?'A':'B').append(occurrences);
+
+        return strTerrain.toString();
+    }
+
+    /**
+     * Create an uncompressed int array from a compressed String representation of
+     * the terrain.
+     * @param t a compressed String representation of the terrain
+     * @return int array representation of the terrain
+     */
+    private static int[] uncompressTerrain(String t) {
+        ArrayList<Integer> terrain = new ArrayList<>();
+        StringBuilder counter = new StringBuilder();
+
+        for (char ch : t.toCharArray()) {
+            if (ch == 'A' || ch == 'B') {
+                if (counter.length() > 0) {
+                    for (int i = 0; i < Integer.parseInt(counter.toString()) - 1; i++) {
+                        terrain.add(terrain.get(terrain.size() - 1));
+                    }
+                    counter = new StringBuilder();
+                }
+                terrain.add(ch == 'A' ? 0 : 1);
+            } else {
+                counter.append(ch);
+            }
+        }
+
+        if (counter.length() > 0) {
+            for (int i = 0; i < Integer.parseInt(counter.toString()) - 1; i++) {
+                terrain.add(terrain.get(terrain.size() - 1));
+            }
+        }
+
+        int[] rt = new int[terrain.size()];
+        for (int i = 0; i < terrain.size(); i++) {
+            rt[i] = terrain.get(i);
+        }
+
+        return rt;
+    }
+
+    /**
      * Writes a XML representation of the map
      *
      * @param w
@@ -520,29 +601,6 @@ public class PhysicalGameState {
         }
         w.tag("/units");
         w.tag("/" + this.getClass().getName());
-    }
-
-    String compressTerrain(int[] terrain, int size){
-        StringBuilder strTerrain = new StringBuilder();
-
-        int occurrences = 1;
-        for (int i = 1; i < size; i++) {
-            if(terrain[i]==terrain[i-1])
-                occurrences++;
-            else {
-                strTerrain.append(terrain[i - 1]==0?'A':'B');
-
-                if(occurrences>1)
-                    strTerrain.append(occurrences);
-
-                occurrences=1;
-            }
-        }
-
-        if(occurrences>1)
-            strTerrain.append(terrain[terrain.length-1]==0?'A':'B').append(occurrences);
-
-        return strTerrain.toString();
     }
 
     /**

--- a/src/rts/RemoteGame.java
+++ b/src/rts/RemoteGame.java
@@ -3,9 +3,9 @@ package rts;
 import ai.core.AI;
 import ai.socket.SocketAI;
 import gui.PhysicalGameStatePanel;
-import rts.units.UnitTypeTable;
-import javax.swing.*;
 import java.net.Socket;
+import javax.swing.JFrame;
+import rts.units.UnitTypeTable;
 
 class RemoteGame extends Thread {
 
@@ -52,6 +52,10 @@ class RemoteGame extends Thread {
             // Reset all players
             player_one.reset();
             player_two.reset();
+
+            // allow for pre-game analysis
+            player_one.preGameAnalysis(gameState,0);
+            player_two.preGameAnalysis(gameState,0);
 
             // Setup UI
             JFrame w = PhysicalGameStatePanel.newVisualizer(gameState,640, 640, false, PhysicalGameStatePanel.COLORSCHEME_BLACK);

--- a/src/rts/RemoteGame.java
+++ b/src/rts/RemoteGame.java
@@ -42,7 +42,8 @@ class RemoteGame extends Thread {
             // Generate players
             // player 1 is created from SocketAI
             AI player_one = SocketAI.createFromExistingSocket(100, 0, unitTypeTable,
-                gameSettings.getSerializationType(), socket);
+                gameSettings.getSerializationType(), gameSettings.isIncludeConstantsInState(),
+                gameSettings.isCompressTerrain(), socket);
             // player 2 is created using the info from gameSettings
             java.lang.reflect.Constructor cons2 = Class.forName(gameSettings.getAI2())
                 .getConstructor(UnitTypeTable.class);


### PR DESCRIPTION
In this PR, I have added two additional boolean properties to `config.properties`.

The first property, `constants_in_state`, allow users to configure whether they want constant data to be transmitted in every state during socket communication. By constant data, I mean the terrain vector and the map width and height. If `true`, everything remains as is. If `false`, this data will be made available only in the pre-game analysis state. I did this in hopes to reduce the message size for network transmission, as well as overhead in creating the JSON and XML strings.

The second property, `compress_terrain`, lets users configure if they want the terrain vector to be compressed using run-length encoding, like I describe in https://github.com/santiontanon/microrts/issues/57#issue-524836849. I have provided methods to both compress and decompress the terrain and made sure both functions are reversible. I also check if the terrain is compressed when received in the `fromxml()` and `fromJSON()` methods and decompress it.

The way I see it, as long as the values of these new properties are kept, no breaking changes have been made to microRTS. I am currently using the modified message in my fork of python-microRTS with ease. I also provide the means to decompress the terrain data in Python, if anyone is interested.

I believe this closes #57.