### PR TITLE
Removed unnecessary null initialization of objects

### DIFF
--- a/src/ai/abstraction/AbstractionLayerAI.java
+++ b/src/ai/abstraction/AbstractionLayerAI.java
@@ -38,7 +38,7 @@ public abstract class AbstractionLayerAI extends AIWithComputationBudget {
     // In case the GameState is cloned, and the Unit pointers in the "actions" map change, this variable
     // saves a pointer to the previous GameState, if it's different than the current one, then we need to find a mapping
     // between the old units and the new ones
-    protected GameState lastGameState = null;
+    protected GameState lastGameState;
 
     public AbstractionLayerAI(PathFinding a_pf) {
         super(-1, -1);

--- a/src/ai/abstraction/pathfinding/AStarPathFinding.java
+++ b/src/ai/abstraction/pathfinding/AStarPathFinding.java
@@ -26,13 +26,13 @@ public class AStarPathFinding extends PathFinding {
     public static int iterations = 0;   // this is a debugging variable    
     public static int accumlength = 0;   // this is a debugging variable    
     
-    Boolean free[][] = null;
-    int closed[] = null;
-    int open[] = null;  // open list
-    int heuristic[] = null;     // heuristic value of the elements in 'open'
-    int parents[] = null;
-    int cost[] = null;     // cost of reaching a given position so far
-    int inOpenOrClosed[] = null;
+    Boolean free[][];
+    int closed[];
+    int open[];  // open list
+    int heuristic[];     // heuristic value of the elements in 'open'
+    int parents[];
+    int cost[];     // cost of reaching a given position so far
+    int inOpenOrClosed[];
     int openinsert = 0;
     
     

--- a/src/ai/abstraction/pathfinding/BFSPathFinding.java
+++ b/src/ai/abstraction/pathfinding/BFSPathFinding.java
@@ -19,11 +19,11 @@ public class BFSPathFinding extends PathFinding {
     public static int iterations = 0;   // this is a debugging variable    
     public static int accumlength = 0;   // this is a debugging variable    
     
-    Boolean free[][] = null;
-    int closed[] = null;
-    int open[] = null;
-    int inOpenOrClosed[] = null;
-    int parents[] = null;
+    Boolean free[][];
+    int closed[];
+    int open[];
+    int inOpenOrClosed[];
+    int parents[];
     int openinsert = 0;
     int openremove = 0;
     

--- a/src/ai/abstraction/pathfinding/FloodFillPathFinding.java
+++ b/src/ai/abstraction/pathfinding/FloodFillPathFinding.java
@@ -15,8 +15,8 @@ public class FloodFillPathFinding extends PathFinding {
 	PathFinding altPF=new AStarPathFinding();
 	private static final int ALT_THRESHOLD = 0;
 	HashMap<Integer,int[][]> cache= new HashMap<>();
-	boolean free[][] = null;
-	int distances[][] = null;
+	boolean free[][];
+	int distances[][];
 	int w,h;
 	int lastFrame=-1;
 	@Override

--- a/src/ai/ahtn/AHTNAI.java
+++ b/src/ai/ahtn/AHTNAI.java
@@ -36,14 +36,14 @@ import rts.units.UnitTypeTable;
 public class AHTNAI extends AIWithComputationBudget {
     public static int DEBUG = 0;
     
-    String domainFileName = null;
-    DomainDefinition dd = null;
+    String domainFileName;
+    DomainDefinition dd;
 
-    EvaluationFunction ef = null;
-    AI playoutAI = null;
+    EvaluationFunction ef;
+    AI playoutAI;
     public int PLAYOUT_LOOKAHEAD = 100;
         
-    List<MethodDecomposition> actionsBeingExecuted = null;
+    List<MethodDecomposition> actionsBeingExecuted;
     
     
     public AHTNAI(UnitTypeTable utt) throws Exception {

--- a/src/ai/ahtn/domain/Clause.java
+++ b/src/ai/ahtn/domain/Clause.java
@@ -28,8 +28,8 @@ public class Clause {
     public static final int CLAUSE_FALSE = 5;
     
     int type = CLAUSE_AND;
-    Term term = null;
-    Clause clauses[] = null;
+    Term term;
+    Clause clauses[];
     
     // variables to continue finding matches after the first:
     List<List<Binding>> matches_left;

--- a/src/ai/ahtn/domain/DomainDefinition.java
+++ b/src/ai/ahtn/domain/DomainDefinition.java
@@ -19,7 +19,7 @@ import java.util.List;
 public class DomainDefinition {
     public static int DEBUG = 0;
     
-    String name = null;
+    String name;
     List<HTNOperator> operators = new LinkedList<>();
     List<HTNMethod> methods = new LinkedList<>();
     

--- a/src/ai/ahtn/domain/LispParser/LispElement.java
+++ b/src/ai/ahtn/domain/LispParser/LispElement.java
@@ -14,8 +14,8 @@ import java.util.List;
  * @author santi
  */
 public class LispElement {
-    public String element = null;
-    public List<LispElement> children = null;
+    public String element;
+    public List<LispElement> children;
     
     // create a new atom:
     public LispElement(String e) {

--- a/src/ai/ahtn/domain/MethodDecomposition.java
+++ b/src/ai/ahtn/domain/MethodDecomposition.java
@@ -39,11 +39,11 @@ public class MethodDecomposition {
     public static final int EXECUTION_CHOICE_POINT = 4;
     
     protected int type = METHOD_CONDITION;
-    protected Clause clause = null;
-    protected Term term = null;
-    protected MethodDecomposition[] subelements = null;
+    protected Clause clause;
+    protected Term term;
+    protected MethodDecomposition[] subelements;
     
-    HTNMethod method = null;
+    HTNMethod method;
     
     /*
     executionState:
@@ -55,8 +55,8 @@ public class MethodDecomposition {
     */
     int executionState = 0;
     int operatorExecutingState = 0;
-    List<MethodDecomposition> operatorsBeingExecuted = null;
-    Term updatedTerm = null;
+    List<MethodDecomposition> operatorsBeingExecuted;
+    Term updatedTerm;
     int updatedTermCycle = -1;  // at which game cycle did we update the term last time
     
     

--- a/src/ai/ahtn/planner/AdversarialBoundedDepthPlannerAlphaBeta.java
+++ b/src/ai/ahtn/planner/AdversarialBoundedDepthPlannerAlphaBeta.java
@@ -42,7 +42,7 @@ public class AdversarialBoundedDepthPlannerAlphaBeta {
     GameState gs;
     DomainDefinition dd;
     EvaluationFunction f;
-    AI playoutAI = null;
+    AI playoutAI;
     int PLAYOUT_LOOKAHEAD = 100;
     int maxDepth = 3;
     int operatorExecutionTimeout = 1000;

--- a/src/ai/ahtn/planner/AdversarialChoicePoint.java
+++ b/src/ai/ahtn/planner/AdversarialChoicePoint.java
@@ -38,23 +38,23 @@ public class AdversarialChoicePoint {
                                 // is equivalent to the number of operators executed so far)
     
     // Method: variables to continue finding expansions after the first:
-    List<HTNMethod> possibleMethods = null;
+    List<HTNMethod> possibleMethods;
     
     // Condition: variables to continue finding expansions after the first:
-    Clause updatedClause = null;
+    Clause updatedClause;
     boolean updatedClauseHadAnyMatches = false;
-    List<Binding> lastBindings = null;  // If the bindings found for a next match are the same as
+    List<Binding> lastBindings;  // If the bindings found for a next match are the same as
                                         // the previous one, the new match is ignored (to reduce
                                         // useless branching)
     
     // Variables to restore the execution point of the plan after backtracking:
-    HashMap<MethodDecomposition, MethodDecompositionState> executionState = null;
+    HashMap<MethodDecomposition, MethodDecompositionState> executionState;
     
     // evaluation function:
     public int minimaxType = -1;   // 0: max, 1: min, -1: not yet set.
     public float bestEvaluation = 0;
-    public MethodDecomposition bestMaxPlan = null;
-    public MethodDecomposition bestMinPlan = null;
+    public MethodDecomposition bestMaxPlan;
+    public MethodDecomposition bestMinPlan;
     float alpha = 0;
     float beta = 0;
 

--- a/src/ai/ahtn/planner/MethodDecompositionState.java
+++ b/src/ai/ahtn/planner/MethodDecompositionState.java
@@ -17,7 +17,7 @@ import java.util.List;
 public class MethodDecompositionState {
     int executionState = 0;
     int operatorExecutingState = 0;
-    List<MethodDecomposition> operatorsBeingExecuted = null;
+    List<MethodDecomposition> operatorsBeingExecuted;
 
     public MethodDecompositionState(MethodDecomposition md) {
         executionState = md.getExecutionState();

--- a/src/ai/ahtn/visualization/HTNDomainVisualizer.java
+++ b/src/ai/ahtn/visualization/HTNDomainVisualizer.java
@@ -46,8 +46,8 @@ public class HTNDomainVisualizer {
     int vpadding = 4;
     int hMethodPadding = 16;
     int vMethodPadding  = 16;
-    Font font = null;
-    FontMetrics fm = null;
+    Font font;
+    FontMetrics fm;
     
     
     public HTNDomainVisualizer() {

--- a/src/ai/ahtn/visualization/HTNDomainVisualizerVertical.java
+++ b/src/ai/ahtn/visualization/HTNDomainVisualizerVertical.java
@@ -65,8 +65,8 @@ public class HTNDomainVisualizerVertical {
     int vpadding = 4;
     int hMethodPadding = 32;
     int vMethodPadding  = 8;
-    Font font = null;
-    FontMetrics fm = null;
+    Font font;
+    FontMetrics fm;
     
     
     public HTNDomainVisualizerVertical() {

--- a/src/ai/core/ContinuingAI.java
+++ b/src/ai/core/ContinuingAI.java
@@ -28,7 +28,7 @@ public class ContinuingAI extends AI {
     /**
      * The game state for which the action is being computed
      */
-    protected GameState m_gameStateUsedForComputation = null;
+    protected GameState m_gameStateUsedForComputation;
     
     /**
      * Instantiates the ContinuingAI with an AI that implements {@link InterruptibleAI}.

--- a/src/ai/core/ParameterSpecification.java
+++ b/src/ai/core/ParameterSpecification.java
@@ -13,11 +13,11 @@ import java.util.List;
  * @author santi
  */
 public class ParameterSpecification {
-    public String name = null;
-    public Class type = null;
-    public Object defaultValue = null;
-    public List<Object> possibleValues = null;     // used only if not-null
-    public Double minValue = null, maxValue = null; // for parameters with a range
+    public String name;
+    public Class type;
+    public Object defaultValue;
+    public List<Object> possibleValues;     // used only if not-null
+    public Double minValue, maxValue; // for parameters with a range
     
     
     public ParameterSpecification(String n, Class t, Object dv) {

--- a/src/ai/core/PseudoContinuingAI.java
+++ b/src/ai/core/PseudoContinuingAI.java
@@ -25,7 +25,7 @@ public class PseudoContinuingAI extends AI {
     
     protected AIWithComputationBudget m_AI;
     protected int n_cycles_to_think = 1;
-    protected GameState m_farecastedGameState = null;
+    protected GameState m_farecastedGameState;
     
     public PseudoContinuingAI(AIWithComputationBudget ai) {
         m_AI = ai;

--- a/src/ai/evaluation/EvaluationFunctionForwarding.java
+++ b/src/ai/evaluation/EvaluationFunctionForwarding.java
@@ -12,7 +12,7 @@ import rts.GameState;
  */
 public class EvaluationFunctionForwarding extends EvaluationFunction {
     
-    EvaluationFunction baseFunction = null;
+    EvaluationFunction baseFunction;
 
     public EvaluationFunctionForwarding(EvaluationFunction base) {
         baseFunction = base;

--- a/src/ai/machinelearning/bayes/ActionInterdependenceModel.java
+++ b/src/ai/machinelearning/bayes/ActionInterdependenceModel.java
@@ -29,19 +29,19 @@ import util.XMLWriter;
 public class ActionInterdependenceModel extends BayesianModel {
     int estimationMethod = ESTIMATION_COUNTS;
     double calibrationFactor = 0.0;   // how much to crrect probabilities after estimation
-    double []prior_distribution = null;
-    DiscreteCPD []distributions = null;
-    boolean []selectedFeatures = null;
+    double []prior_distribution;
+    DiscreteCPD []distributions;
+    boolean []selectedFeatures;
     int Ysize = 0;
     int YtypeSize = 0;
     int Xsizes[];
     
-    int []action_allowed_counts_prior = null;    // number of times actions were allowed
-    int [][]selected_allowed_action_prior = null;    // [i][j]: number of times i was selected when j was also allowed
+    int []action_allowed_counts_prior;    // number of times actions were allowed
+    int [][]selected_allowed_action_prior;    // [i][j]: number of times i was selected when j was also allowed
     
-    List<Integer> allPossibleActionsTypes = null;
-    int []actiontypes_allowed_counts_prior = null;    // number of times action types were allowed
-    int [][]selected_allowed_actiontype_prior = null;    // [i][j]: number of times i was selected when j was also allowed
+    List<Integer> allPossibleActionsTypes;
+    int []actiontypes_allowed_counts_prior;    // number of times action types were allowed
+    int [][]selected_allowed_actiontype_prior;    // [i][j]: number of times i was selected when j was also allowed
 
     boolean consider_individual_actions = false;
     boolean consider_action_types = true;

--- a/src/ai/machinelearning/bayes/BayesianModel.java
+++ b/src/ai/machinelearning/bayes/BayesianModel.java
@@ -28,9 +28,9 @@ public abstract class BayesianModel extends UnitActionProbabilityDistribution {
     
     public static final double laplaceBeta = 1.0;    
     
-    protected List<UnitAction> allPossibleActions = null;
-    protected FeatureGenerator featureGenerator = null;
-    protected String name = null;
+    protected List<UnitAction> allPossibleActions;
+    protected FeatureGenerator featureGenerator;
+    protected String name;
     
     public BayesianModel(UnitTypeTable utt, FeatureGenerator fg, String a_name) {
         super(utt);

--- a/src/ai/machinelearning/bayes/BayesianModelByUnitTypeWithDefaultModel.java
+++ b/src/ai/machinelearning/bayes/BayesianModelByUnitTypeWithDefaultModel.java
@@ -19,10 +19,10 @@ import util.XMLWriter;
  * @author santi
  */
 public class BayesianModelByUnitTypeWithDefaultModel extends BayesianModel {
-    BayesianModel templateModel = null;
+    BayesianModel templateModel;
     
     HashMap<UnitType,BayesianModel> unitModels = new HashMap<>();
-    BayesianModel defaultModel = null;
+    BayesianModel defaultModel;
     
     public BayesianModelByUnitTypeWithDefaultModel(UnitTypeTable utt, BayesianModel tm, String a_name) {
         super(utt, tm.featureGenerator, a_name);

--- a/src/ai/machinelearning/bayes/CalibratedNaiveBayes.java
+++ b/src/ai/machinelearning/bayes/CalibratedNaiveBayes.java
@@ -30,9 +30,9 @@ public class CalibratedNaiveBayes extends BayesianModel {
         
     int estimationMethod = ESTIMATION_COUNTS;
     double calibrationFactor = 0.0;   // how much to crrect probabilities after estimation
-    double []prior_distribution = null;
-    DiscreteCPD []distributions = null;
-    boolean []selectedFeatures = null;
+    double []prior_distribution;
+    DiscreteCPD []distributions;
+    boolean []selectedFeatures;
     int Ysize = 0;
     int Xsizes[];
    

--- a/src/ai/machinelearning/bayes/TrainingInstance.java
+++ b/src/ai/machinelearning/bayes/TrainingInstance.java
@@ -16,9 +16,9 @@ import rts.units.Unit;
  * @author santi
  */
 public class TrainingInstance {
-    public GameState gs = null;
-    public Unit u = null;
-    public UnitAction ua = null;
+    public GameState gs;
+    public Unit u;
+    public UnitAction ua;
     
     public TrainingInstance(GameState a_gs, long uID, UnitAction a_ua) throws Exception {
         gs = a_gs;

--- a/src/ai/mcts/MCTSNode.java
+++ b/src/ai/mcts/MCTSNode.java
@@ -18,12 +18,12 @@ public abstract class MCTSNode {
     public static Random r = new Random();
 
     public int type;    // 0 : max, 1 : min, -1: Game-over
-    public MCTSNode parent = null;
-    public GameState gs = null;
+    public MCTSNode parent;
+    public GameState gs;
     public int depth = 0;  // the depth in the tree
 
-    public List<PlayerAction> actions = null;
-    public List<MCTSNode> children = null;
+    public List<PlayerAction> actions;
+    public List<MCTSNode> children;
 
     public double accum_evaluation = 0;
     public int visit_count = 0;

--- a/src/ai/mcts/believestatemcts/BS1_NaiveMCTS.java
+++ b/src/ai/mcts/believestatemcts/BS1_NaiveMCTS.java
@@ -23,7 +23,7 @@ import rts.units.UnitTypeTable;
  */
 public class BS1_NaiveMCTS extends NaiveMCTS implements AIWithBelieveState {
 
-    GameState initialGameState = null;
+    GameState initialGameState;
     
     // list of units we "believe" exist (for now it's just "last seen" position)
     List<Unit> lastKnownPosition = new LinkedList<>();

--- a/src/ai/mcts/believestatemcts/BS2_NaiveMCTS.java
+++ b/src/ai/mcts/believestatemcts/BS2_NaiveMCTS.java
@@ -23,11 +23,11 @@ import rts.units.UnitTypeTable;
  */
 public class BS2_NaiveMCTS extends NaiveMCTS implements AIWithBelieveState {
 
-    GameState initialGameState = null;
+    GameState initialGameState;
     
     // list of units we "believe" exist (for now it's just "last seen" position)
     List<Unit> lastKnownPosition = new LinkedList<>();
-    PartiallyObservableGameState lastObservedGame = null;
+    PartiallyObservableGameState lastObservedGame;
 
     public BS2_NaiveMCTS(UnitTypeTable utt) {
         super(utt);

--- a/src/ai/mcts/believestatemcts/BS3_NaiveMCTS.java
+++ b/src/ai/mcts/believestatemcts/BS3_NaiveMCTS.java
@@ -28,10 +28,10 @@ import rts.units.UnitTypeTable;
  */
 public class BS3_NaiveMCTS extends NaiveMCTS implements AIWithBelieveState {
 
-    GameState initialGameState = null;
+    GameState initialGameState;
     List<Unit> lastKnownPosition = new LinkedList<>();
     List<Unit> inferedUnits = new LinkedList<>();
-    PartiallyObservableGameState lastObservedGame = null;
+    PartiallyObservableGameState lastObservedGame;
     boolean[] typeSeen;
 
     public BS3_NaiveMCTS(UnitTypeTable utt) {

--- a/src/ai/mcts/informedmcts/InformedNaiveMCTS.java
+++ b/src/ai/mcts/informedmcts/InformedNaiveMCTS.java
@@ -30,16 +30,16 @@ import ai.core.InterruptibleAI;
  */
 public class InformedNaiveMCTS extends AIWithComputationBudget implements InterruptibleAI {
     public static int DEBUG = 0;
-    public EvaluationFunction ef = null;
-    UnitTypeTable utt = null;
+    public EvaluationFunction ef;
+    UnitTypeTable utt;
        
     Random r = new Random();
     public AI playoutPolicy = new RandomBiasedAI();
-    UnitActionProbabilityDistribution bias = null;
+    UnitActionProbabilityDistribution bias;
     long max_actions_so_far = 0;
     
-    GameState gs_to_start_from = null;
-    InformedNaiveMCTSNode tree = null;
+    GameState gs_to_start_from;
+    InformedNaiveMCTSNode tree;
     int current_iteration = 0;
             
     public int MAXSIMULATIONTIME = 1024;

--- a/src/ai/mcts/informedmcts/InformedNaiveMCTSNode.java
+++ b/src/ai/mcts/informedmcts/InformedNaiveMCTSNode.java
@@ -26,13 +26,13 @@ public class InformedNaiveMCTSNode extends MCTSNode {
     public static float C = 0.05f;   // exploration constant for UCB1
     
     boolean hasMoreActions = true;
-    public PlayerActionGenerator moveGenerator = null;
+    public PlayerActionGenerator moveGenerator;
     HashMap<BigInteger,InformedNaiveMCTSNode> childrenMap = new LinkedHashMap<>();    // associates action codes with children
     // Decomposition of the player actions in unit actions, and their contributions:
-    public List<InformedUnitActionTableEntry> unitActionTable = null;
+    public List<InformedUnitActionTableEntry> unitActionTable;
     double evaluation_bound;    // this is the maximum positive value that the evaluation function can return
     public BigInteger multipliers[];
-    UnitActionProbabilityDistribution model = null;
+    UnitActionProbabilityDistribution model;
     
 
 

--- a/src/ai/mcts/informedmcts/InformedUnitActionTableEntry.java
+++ b/src/ai/mcts/informedmcts/InformedUnitActionTableEntry.java
@@ -15,10 +15,10 @@ import rts.units.Unit;
 public class InformedUnitActionTableEntry {
     public Unit u;
     public int nactions = 0;
-    public List<UnitAction> actions = null;
-    public double[] prior_distribution = null;
-    public double[] accum_evaluation = null;
-    public int[] visit_count = null;
+    public List<UnitAction> actions;
+    public double[] prior_distribution;
+    public double[] accum_evaluation;
+    public int[] visit_count;
     
     
     public InformedUnitActionTableEntry(Unit a_u, List<UnitAction> a_actions, double []a_prior) 

--- a/src/ai/mcts/mlps/MLPSMCTS.java
+++ b/src/ai/mcts/mlps/MLPSMCTS.java
@@ -24,14 +24,14 @@ import ai.core.InterruptibleAI;
  */
 public class MLPSMCTS extends AIWithComputationBudget implements InterruptibleAI {
     public static int DEBUG = 0;
-    public EvaluationFunction ef = null;
+    public EvaluationFunction ef;
        
     Random r = new Random();
     public AI randomAI = new RandomBiasedAI();
     long max_actions_so_far = 0;
     
-    GameState gs_to_start_from = null;
-    MLPSNode tree = null;
+    GameState gs_to_start_from;
+    MLPSNode tree;
     int current_iteration = 0;
             
     public int MAXSIMULATIONTIME = 1024;

--- a/src/ai/mcts/mlps/MLPSNode.java
+++ b/src/ai/mcts/mlps/MLPSNode.java
@@ -30,12 +30,12 @@ public class MLPSNode extends MCTSNode {
     static public int DEBUG = 0;
         
     boolean hasMoreActions = true;
-    public PlayerActionGenerator moveGenerator = null;
+    public PlayerActionGenerator moveGenerator;
     HashMap<Long,MLPSNode> childrenMap = new LinkedHashMap<>();    // associates action codes with children
     // Decomposition of the player actions in unit actions, and their contributions:
-    public List<UnitActionTableEntry> unitActionTable = null;
-    public List<double[]> UCBExplorationScores = null;
-    public List<double[]> UCBExploitationScores = null;
+    public List<UnitActionTableEntry> unitActionTable;
+    public List<double[]> UCBExplorationScores;
+    public List<double[]> UCBExploitationScores;
     double evaluation_bound = 0;
     int max_nactions = 0;
     

--- a/src/ai/mcts/naivemcts/NaiveMCTS.java
+++ b/src/ai/mcts/naivemcts/NaiveMCTS.java
@@ -24,14 +24,14 @@ import ai.core.InterruptibleAI;
  */
 public class NaiveMCTS extends AIWithComputationBudget implements InterruptibleAI {
     public static int DEBUG = 0;
-    public EvaluationFunction ef = null;
+    public EvaluationFunction ef;
        
     Random r = new Random();
     public AI playoutPolicy = new RandomBiasedAI();
     protected long max_actions_so_far = 0;
     
-    protected GameState gs_to_start_from = null;
-    protected NaiveMCTSNode tree = null;
+    protected GameState gs_to_start_from;
+    protected NaiveMCTSNode tree;
     protected int current_iteration = 0;
             
     public int MAXSIMULATIONTIME = 1024;

--- a/src/ai/mcts/naivemcts/NaiveMCTSNode.java
+++ b/src/ai/mcts/naivemcts/NaiveMCTSNode.java
@@ -27,10 +27,10 @@ public class NaiveMCTSNode extends MCTSNode {
     
     boolean forceExplorationOfNonSampledActions = true;
     boolean hasMoreActions = true;
-    public PlayerActionGenerator moveGenerator = null;
+    public PlayerActionGenerator moveGenerator;
     HashMap<BigInteger,NaiveMCTSNode> childrenMap = new LinkedHashMap<>();    // associates action codes with children
     // Decomposition of the player actions in unit actions, and their contributions:
-    public List<UnitActionTableEntry> unitActionTable = null;
+    public List<UnitActionTableEntry> unitActionTable;
     double evaluation_bound;    // this is the maximum positive value that the evaluation function can return
     public BigInteger multipliers[];
 

--- a/src/ai/mcts/naivemcts/TwoPhaseNaiveMCTS.java
+++ b/src/ai/mcts/naivemcts/TwoPhaseNaiveMCTS.java
@@ -24,14 +24,14 @@ import ai.core.InterruptibleAI;
  */
 public class TwoPhaseNaiveMCTS extends AIWithComputationBudget implements InterruptibleAI {
     public static int DEBUG = 0;
-    public EvaluationFunction ef = null;
+    public EvaluationFunction ef;
        
     Random r = new Random();
     public AI randomAI = new RandomBiasedAI();
     long max_actions_so_far = 0;
     
-    GameState gs_to_start_from = null;
-    NaiveMCTSNode tree = null;
+    GameState gs_to_start_from;
+    NaiveMCTSNode tree;
     int node_creation_ID = 0;
     int n_phase1_iterations_left = -1;      // this is set in the first cycle of execution for each action
     int n_phase1_milliseconds_left = -1;      // this is set in the first cycle of execution for each action

--- a/src/ai/mcts/naivemcts/TwoPhaseNaiveMCTSPerNode.java
+++ b/src/ai/mcts/naivemcts/TwoPhaseNaiveMCTSPerNode.java
@@ -24,14 +24,14 @@ import ai.core.InterruptibleAI;
  */
 public class TwoPhaseNaiveMCTSPerNode extends AIWithComputationBudget implements InterruptibleAI {
     public static int DEBUG = 0;
-    public EvaluationFunction ef = null;
+    public EvaluationFunction ef;
        
     Random r = new Random();
     public AI randomAI = new RandomBiasedAI();
     long max_actions_so_far = 0;
     
-    GameState gs_to_start_from = null;
-    TwoPhaseNaiveMCTSNode tree = null;
+    GameState gs_to_start_from;
+    TwoPhaseNaiveMCTSNode tree;
     int node_creation_ID = 0;
             
     public int MAXSIMULATIONTIME = 1024;

--- a/src/ai/mcts/naivemcts/UnitActionTableEntry.java
+++ b/src/ai/mcts/naivemcts/UnitActionTableEntry.java
@@ -15,7 +15,7 @@ import rts.units.Unit;
 public class UnitActionTableEntry {
     public Unit u;
     public int nactions = 0;
-    public List<UnitAction> actions = null;
-    public double[] accum_evaluation = null;
-    public int[] visit_count = null;
+    public List<UnitAction> actions;
+    public double[] accum_evaluation;
+    public int[] visit_count;
 }

--- a/src/ai/mcts/uct/DownsamplingUCT.java
+++ b/src/ai/mcts/uct/DownsamplingUCT.java
@@ -24,14 +24,14 @@ import ai.core.InterruptibleAI;
  */
 public class DownsamplingUCT extends AIWithComputationBudget implements InterruptibleAI {
     public static final int DEBUG = 0;
-    EvaluationFunction ef = null;
+    EvaluationFunction ef;
        
     Random r = new Random();
     AI randomAI = new RandomBiasedAI();
     long max_actions_so_far = 0;
     
-    GameState gs_to_start_from = null;
-    DownsamplingUCTNode tree = null;
+    GameState gs_to_start_from;
+    DownsamplingUCTNode tree;
     
     // statistics:
     public long total_runs = 0;

--- a/src/ai/mcts/uct/DownsamplingUCTNode.java
+++ b/src/ai/mcts/uct/DownsamplingUCTNode.java
@@ -24,14 +24,14 @@ public class DownsamplingUCTNode {
     static float C = 0.05f;   // this is the constant that regulates exploration vs exploitation, it must be tuned for each domain
     
     public int type;    // 0 : max, 1 : min, -1: Game-over
-    DownsamplingUCTNode parent = null;
+    DownsamplingUCTNode parent;
     public GameState gs;
     int depth = 0;  // the depth in the tree
     
     boolean hasMoreActions = true;
-    PlayerActionGenerator moveGenerator = null;
-    public List<PlayerAction> actions = null;
-    public List<DownsamplingUCTNode> children = null;
+    PlayerActionGenerator moveGenerator;
+    public List<PlayerAction> actions;
+    public List<DownsamplingUCTNode> children;
     float evaluation_bound = 0;
     float accum_evaluation = 0;
     int visit_count = 0;

--- a/src/ai/mcts/uct/UCT.java
+++ b/src/ai/mcts/uct/UCT.java
@@ -24,14 +24,14 @@ import ai.core.InterruptibleAI;
  */
 public class UCT extends AIWithComputationBudget implements InterruptibleAI {
     public static int DEBUG = 0;
-    EvaluationFunction ef = null;
+    EvaluationFunction ef;
        
     Random r = new Random();
     AI randomAI = new RandomBiasedAI();
     long max_actions_so_far = 0;
     
-    GameState gs_to_start_from = null;
-    public UCTNode tree = null;
+    GameState gs_to_start_from;
+    public UCTNode tree;
     
     // statistics:
     public long total_runs = 0;

--- a/src/ai/mcts/uct/UCTFirstPlayUrgency.java
+++ b/src/ai/mcts/uct/UCTFirstPlayUrgency.java
@@ -24,14 +24,14 @@ import ai.core.InterruptibleAI;
  */
 public class UCTFirstPlayUrgency extends AIWithComputationBudget implements InterruptibleAI {
     public static int DEBUG = 0;
-    EvaluationFunction ef = null;
+    EvaluationFunction ef;
        
     Random r = new Random();
     AI randomAI = new RandomBiasedAI();
     long max_actions_so_far = 0;
     
-    GameState gs_to_start_from = null;
-    public UCTNodeFirstPlayUrgency tree = null;
+    GameState gs_to_start_from;
+    public UCTNodeFirstPlayUrgency tree;
     
     // statistics:
     public long total_runs = 0;

--- a/src/ai/mcts/uct/UCTNode.java
+++ b/src/ai/mcts/uct/UCTNode.java
@@ -21,14 +21,14 @@ public class UCTNode {
 //    public static float C = 1;   // this is the constant that regulates exploration vs exploitation, it must be tuned for each domain
     
     public int type;    // 0 : max, 1 : min, -1: Game-over
-    UCTNode parent = null;
+    UCTNode parent;
     public GameState gs;
     int depth = 0;  // the depth in the tree
     
     boolean hasMoreActions = true;
-    PlayerActionGenerator moveGenerator = null;
-    public List<PlayerAction> actions = null;
-    public List<UCTNode> children = null;
+    PlayerActionGenerator moveGenerator;
+    public List<PlayerAction> actions;
+    public List<UCTNode> children;
     float evaluation_bound = 0;
     float accum_evaluation = 0;
     int visit_count = 0;

--- a/src/ai/mcts/uct/UCTNodeFirstPlayUrgency.java
+++ b/src/ai/mcts/uct/UCTNodeFirstPlayUrgency.java
@@ -25,15 +25,15 @@ public class UCTNodeFirstPlayUrgency {
 //    static float C = 1;   // this is the constant that regulates exploration vs exploitation, it must be tuned for each domain
     
     public int type;    // 0 : max, 1 : min, -1: Game-over
-    UCTNodeFirstPlayUrgency parent = null;
+    UCTNodeFirstPlayUrgency parent;
     public GameState gs;
     int depth = 0;  // the depth in the tree
     
     boolean hasMoreActions = true;
-    PlayerActionGenerator moveGenerator = null;
-    public List<PlayerAction> actions = null;
+    PlayerActionGenerator moveGenerator;
+    public List<PlayerAction> actions;
     HashMap<Long,UCTNodeFirstPlayUrgency> childrenMap = new LinkedHashMap<>();    // associates action codes with children
-    public List<UCTNodeFirstPlayUrgency> children = null;
+    public List<UCTNodeFirstPlayUrgency> children;
     float evaluation_bound = 0;
     float accum_evaluation = 0;
     int visit_count = 0;

--- a/src/ai/mcts/uct/UCTUnitActions.java
+++ b/src/ai/mcts/uct/UCTUnitActions.java
@@ -24,14 +24,14 @@ import ai.core.InterruptibleAI;
  */
 public class UCTUnitActions extends AIWithComputationBudget implements InterruptibleAI {
     public static final int DEBUG = 0;
-    EvaluationFunction ef = null;
+    EvaluationFunction ef;
        
     Random r = new Random();
     AI randomAI = new RandomBiasedAI();
     long max_actions_so_far = 0;
     
-    GameState gs_to_start_from = null;
-    UCTUnitActionsNode tree = null;
+    GameState gs_to_start_from;
+    UCTUnitActionsNode tree;
     int MAX_TREE_DEPTH = 10;
     
     // statistics:

--- a/src/ai/mcts/uct/UCTUnitActionsNode.java
+++ b/src/ai/mcts/uct/UCTUnitActionsNode.java
@@ -21,12 +21,12 @@ public class UCTUnitActionsNode {
     static float C = 0.05f;   // this is the constant that regulates exploration vs exploitation, it must be tuned for each domain
     
     public int type;    // 0 : max, 1 : min, -1: Game-over
-    UCTUnitActionsNode parent = null;
+    UCTUnitActionsNode parent;
     public GameState gs;
     int depth = 0;
     
-    public List<PlayerAction> actions = null;
-    public List<UCTUnitActionsNode> children = null;
+    public List<PlayerAction> actions;
+    public List<UCTUnitActionsNode> children;
     float evaluation_bound = 0;
     float accum_evaluation = 0;
     int visit_count = 0;

--- a/src/ai/minimax/ABCD/ABCD.java
+++ b/src/ai/minimax/ABCD/ABCD.java
@@ -40,9 +40,9 @@ public class ABCD extends AI {
     long max_nodes_so_far = 0;
     
     int MAXDEPTH = 4;
-    AI playoutAI = null;
+    AI playoutAI;
     int maxPlayoutTime = 100;
-    EvaluationFunction ef = null;
+    EvaluationFunction ef;
     protected int defaultNONEduration = 8;
     
     

--- a/src/ai/minimax/ABCD/IDABCD.java
+++ b/src/ai/minimax/ABCD/IDABCD.java
@@ -57,14 +57,14 @@ public class IDABCD extends AIWithComputationBudget implements InterruptibleAI {
     long max_leaves_so_far = 0;
     long max_nodes_so_far = 0;
     
-    AI playoutAI = null;
+    AI playoutAI;
     int maxPlayoutTime = 100;
-    EvaluationFunction ef = null;
+    EvaluationFunction ef;
     boolean performGreedyActionScan = false;
 
     int max_consecutive_frames_searching_so_far = 0;
 
-    GameState gs_to_start_from = null;
+    GameState gs_to_start_from;
     int consecutive_frames_searching = 0;
     int last_depth = 1;
     int last_nleaves = 0;
@@ -78,9 +78,9 @@ public class IDABCD extends AIWithComputationBudget implements InterruptibleAI {
     double count_time_depth_so_far = 0;
         
     boolean treeIsComplete = true;
-    List<ABCDNode> stack = null;
-    Pair<PlayerAction,Float> lastResult = null;
-    PlayerAction bestMove = null;
+    List<ABCDNode> stack;
+    Pair<PlayerAction,Float> lastResult;
+    PlayerAction bestMove;
     int playerForThisComputation;
 
     

--- a/src/ai/minimax/RTMiniMax/IDRTMinimax.java
+++ b/src/ai/minimax/RTMiniMax/IDRTMinimax.java
@@ -40,19 +40,19 @@ public class IDRTMinimax extends AIWithComputationBudget implements Interruptibl
 
     protected int defaultNONEduration = 8;
     
-    EvaluationFunction ef = null;    
+    EvaluationFunction ef;
         
     int max_depth_so_far = 0;
     long max_potential_branching_so_far = 0;
     
     int max_consecutive_frames_searching_so_far = 0;
     
-    GameState gs_to_start_from = null;
+    GameState gs_to_start_from;
     int consecutive_frames_searching = 0;
     int last_lookAhead = 1;
-    List<RTMiniMaxNode> stack = null;
-    Pair<PlayerAction,Float> lastResult = null;
-    PlayerAction bestMove = null;
+    List<RTMiniMaxNode> stack;
+    Pair<PlayerAction,Float> lastResult;
+    PlayerAction bestMove;
     
     Random r = new Random();
     int playerForThisComputation;

--- a/src/ai/minimax/RTMiniMax/RTMiniMaxRandomizedRootNode.java
+++ b/src/ai/minimax/RTMiniMax/RTMiniMaxRandomizedRootNode.java
@@ -14,7 +14,7 @@ import rts.GameState;
 public class RTMiniMaxRandomizedRootNode extends RTMiniMaxNode {
 
     public int iterations_run = 0;
-    float scores[] = null;
+    float scores[];
     
     public RTMiniMaxRandomizedRootNode(GameState a_gs) {
         super(3, a_gs, -EvaluationFunction.VICTORY, EvaluationFunction.VICTORY);

--- a/src/ai/minimax/RTMiniMax/RTMinimax.java
+++ b/src/ai/minimax/RTMiniMax/RTMinimax.java
@@ -33,7 +33,7 @@ public class RTMinimax extends AI {
 
     protected int defaultNONEduration = 8;
     
-    EvaluationFunction ef = null;
+    EvaluationFunction ef;
     
     
     public RTMinimax(UnitTypeTable utt) {

--- a/src/ai/montecarlo/MonteCarlo.java
+++ b/src/ai/montecarlo/MonteCarlo.java
@@ -25,7 +25,7 @@ import ai.core.InterruptibleAI;
  */
 public class MonteCarlo extends AIWithComputationBudget implements InterruptibleAI {
     public static final int DEBUG = 0;
-    EvaluationFunction ef = null;
+    EvaluationFunction ef;
     
     
     public class PlayerActionTableEntry {
@@ -39,10 +39,10 @@ public class MonteCarlo extends AIWithComputationBudget implements Interruptible
     AI randomAI = new RandomBiasedAI();
     long max_actions_so_far = 0;
     
-    PlayerActionGenerator  moveGenerator = null;
+    PlayerActionGenerator  moveGenerator;
     boolean allMovesGenerated = false;
-    List<PlayerActionTableEntry> actions = null;
-    GameState gs_to_start_from = null;
+    List<PlayerActionTableEntry> actions;
+    GameState gs_to_start_from;
     int run = 0;
     int playerForThisComputation;
     

--- a/src/ai/montecarlo/lsi/LSI.java
+++ b/src/ai/montecarlo/lsi/LSI.java
@@ -67,7 +67,7 @@ public class LSI extends AIWithComputationBudget {
 
     private LinkedHashMap<PlayerAction, Pair<Double, Integer>> elitePlayerActions = new LinkedHashMap<>();
     private Set<Unit> nextEpochUnits = new HashSet<>();
-    private Set<Unit> epochUnits = null;
+    private Set<Unit> epochUnits;
 
     private int actionCount;
 

--- a/src/ai/montecarlo/lsi/Sampling.java
+++ b/src/ai/montecarlo/lsi/Sampling.java
@@ -416,9 +416,9 @@ public class Sampling {
         public int idx;
         public Unit u;
         public int nactions = 0;
-        public List<UnitAction> actions = null;
-        public double[] accum_evaluation = null;
-        public int[] visit_count = null;
+        public List<UnitAction> actions;
+        public double[] accum_evaluation;
+        public int[] visit_count;
     }
 
     public enum AgentOrderingType {

--- a/src/ai/portfolio/PortfolioAI.java
+++ b/src/ai/portfolio/PortfolioAI.java
@@ -31,13 +31,13 @@ public class PortfolioAI extends AIWithComputationBudget implements Interruptibl
     public static int DEBUG = 0;
 
     int LOOKAHEAD = 500;
-    AI strategies[] = null;
-    boolean deterministic[] = null;
-    EvaluationFunction evaluation = null;
+    AI strategies[];
+    boolean deterministic[];
+    EvaluationFunction evaluation;
     
-    GameState gs_to_start_from = null;
-    double scores[][] = null;
-    int counts[][] = null;
+    GameState gs_to_start_from;
+    double scores[][];
+    int counts[][];
     int nplayouts = 0;
     int playerForThisComputation;
     

--- a/src/ai/portfolio/portfoliogreedysearch/PGSAI.java
+++ b/src/ai/portfolio/portfoliogreedysearch/PGSAI.java
@@ -45,12 +45,12 @@ public class PGSAI extends AIWithComputationBudget {
     int LOOKAHEAD = 500;
     int I = 1;  // number of iterations for improving a given player
     int R = 1;  // number of times to improve with respect to the response fo the other player
-    EvaluationFunction evaluation = null;
-    HashMap<UnitType, List<UnitScript>> scripts = null;
+    EvaluationFunction evaluation;
+    HashMap<UnitType, List<UnitScript>> scripts;
     UnitTypeTable utt;
     PathFinding pf;
 
-    UnitScript defaultScript = null;
+    UnitScript defaultScript;
 
     long start_time = 0;
     int nplayouts = 0;

--- a/src/ai/portfolio/portfoliogreedysearch/UnitScriptAttack.java
+++ b/src/ai/portfolio/portfoliogreedysearch/UnitScriptAttack.java
@@ -18,8 +18,8 @@ import rts.units.Unit;
  */
 public class UnitScriptAttack extends UnitScript {
     
-    AbstractAction action = null;
-    PathFinding pf = null;
+    AbstractAction action;
+    PathFinding pf;
     
     public UnitScriptAttack(PathFinding a_pf) {
         pf = a_pf;

--- a/src/ai/portfolio/portfoliogreedysearch/UnitScriptBuild.java
+++ b/src/ai/portfolio/portfoliogreedysearch/UnitScriptBuild.java
@@ -20,9 +20,9 @@ import rts.units.UnitType;
  */
 public class UnitScriptBuild extends UnitScript {
     
-    AbstractAction action = null;
-    PathFinding pf = null;
-    UnitType ut = null;
+    AbstractAction action;
+    PathFinding pf;
+    UnitType ut;
     
     public UnitScriptBuild(PathFinding a_pf, UnitType a_ut) {
         pf = a_pf;

--- a/src/ai/portfolio/portfoliogreedysearch/UnitScriptHarvest.java
+++ b/src/ai/portfolio/portfoliogreedysearch/UnitScriptHarvest.java
@@ -20,9 +20,9 @@ import rts.units.UnitTypeTable;
  */
 public class UnitScriptHarvest extends UnitScript {
     
-    AbstractAction action = null;
-    PathFinding pf = null;
-    UnitTypeTable utt = null;
+    AbstractAction action;
+    PathFinding pf;
+    UnitTypeTable utt;
     
     public UnitScriptHarvest(PathFinding a_pf, UnitTypeTable a_utt) {
         pf = a_pf;

--- a/src/ai/portfolio/portfoliogreedysearch/UnitScriptIdle.java
+++ b/src/ai/portfolio/portfoliogreedysearch/UnitScriptIdle.java
@@ -17,7 +17,7 @@ import rts.units.Unit;
  */
 public class UnitScriptIdle extends UnitScript {
     
-    AbstractAction action = null;
+    AbstractAction action;
     
     public UnitScriptIdle() {
     }

--- a/src/ai/portfolio/portfoliogreedysearch/UnitScriptTrain.java
+++ b/src/ai/portfolio/portfoliogreedysearch/UnitScriptTrain.java
@@ -18,8 +18,8 @@ import rts.units.UnitType;
  */
 public class UnitScriptTrain extends UnitScript {
     
-    AbstractAction action = null;
-    UnitType ut = null;
+    AbstractAction action;
+    UnitType ut;
     
     public UnitScriptTrain(UnitType a_ut) {
         ut = a_ut;

--- a/src/ai/portfolio/portfoliogreedysearch/UnitScriptsAI.java
+++ b/src/ai/portfolio/portfoliogreedysearch/UnitScriptsAI.java
@@ -28,8 +28,8 @@ public class UnitScriptsAI extends AI {
     UnitScript scriptsInput[];
     List<Unit> unitsInput;
     HashMap<Long,UnitScript> scripts = new HashMap<>();
-    HashMap<UnitType, List<UnitScript>> allScripts = null;
-    UnitScript defaultScript = null;
+    HashMap<UnitType, List<UnitScript>> allScripts;
+    UnitScript defaultScript;
     
     
     public UnitScriptsAI(UnitScript a_scripts[], List<Unit> a_units,

--- a/src/ai/scv/SCV.java
+++ b/src/ai/scv/SCV.java
@@ -63,15 +63,15 @@ public class SCV extends AIWithComputationBudget {
         double ltd3;
     }
     
-    AI strategies[] = null;
+    AI strategies[];
     int playerForThisComputation;
-    GameState gs_to_start_from = null;
-    SimpleLogistic rf = null;
-    UnitTypeTable localUtt = null;
-    Instances dataSet = null;
-    long tempoInicial = 0;
+    GameState gs_to_start_from;
+    SimpleLogistic rf;
+    UnitTypeTable localUtt;
+    Instances dataSet;
+    long tempoInicial;
     
-    HashMap<String, HashMap<Integer, List<infBattles> > > indice = null;
+    HashMap<String, HashMap<Integer, List<infBattles> > > indice;
     int heightMap;
     
     // This is the default constructor that microRTS will call

--- a/src/ai/socket/JSONSocketWrapperAI.java
+++ b/src/ai/socket/JSONSocketWrapperAI.java
@@ -46,12 +46,12 @@ public class JSONSocketWrapperAI {
 
 
     private static class SocketWrapperAI extends Thread {
-        Socket socket = null;
+        Socket socket;
         int clientNumber = 0;
         int time_budget = 100;
         int iterations_budget = 0;
-        UnitTypeTable utt = null;
-        AIWithComputationBudget ai = null;
+        UnitTypeTable utt;
+        AIWithComputationBudget ai;
         
 
         public SocketWrapperAI(Socket socket, int clientNumber, AIWithComputationBudget a_ai) {

--- a/src/ai/socket/SocketAI.java
+++ b/src/ai/socket/SocketAI.java
@@ -27,19 +27,19 @@ import util.XMLWriter;
  * @author santi
  */
 public class SocketAI extends AIWithComputationBudget {
-    public static int DEBUG = 0;
+    public static int DEBUG;
     
     public static final int LANGUAGE_XML = 1;
     public static final int LANGUAGE_JSON = 2;
     
-    UnitTypeTable utt = null;
+    UnitTypeTable utt;
             
     int communication_language = LANGUAGE_XML;
     String serverAddress = "127.0.0.1";
     int serverPort = 9898;
-    Socket socket = null;
-    BufferedReader in_pipe = null;
-    PrintWriter out_pipe = null;
+    Socket socket;
+    BufferedReader in_pipe;
+    PrintWriter out_pipe;
     
     public SocketAI(UnitTypeTable a_utt) {
         super(100,-1);

--- a/src/ai/socket/XMLSocketWrapperAI.java
+++ b/src/ai/socket/XMLSocketWrapperAI.java
@@ -48,12 +48,12 @@ public class XMLSocketWrapperAI {
     
 
     private static class SocketWrapperAI extends Thread {
-        Socket socket = null;
+        Socket socket;
         int clientNumber = 0;
         int time_budget = 100;
         int iterations_budget = 0;
-        UnitTypeTable utt = null;
-        AIWithComputationBudget ai = null;
+        UnitTypeTable utt;
+        AIWithComputationBudget ai;
 
         public SocketWrapperAI(Socket a_socket, int a_clientNumber, AIWithComputationBudget a_ai) {
             socket = a_socket;

--- a/src/ai/stochastic/UnitActionProbabilityDistribution.java
+++ b/src/ai/stochastic/UnitActionProbabilityDistribution.java
@@ -16,7 +16,7 @@ import rts.units.UnitTypeTable;
  * @author santi
  */
 public abstract class UnitActionProbabilityDistribution {
-    protected UnitTypeTable utt = null;
+    protected UnitTypeTable utt;
     
     public UnitActionProbabilityDistribution(UnitTypeTable a_utt) {
         utt = a_utt;

--- a/src/ai/stochastic/UnitActionProbabilityDistributionAI.java
+++ b/src/ai/stochastic/UnitActionProbabilityDistributionAI.java
@@ -24,9 +24,9 @@ public class UnitActionProbabilityDistributionAI extends AI {
     public static int DEBUG = 0;
     
     Random r = new Random();
-    UnitActionProbabilityDistribution model = null;
+    UnitActionProbabilityDistribution model;
     String modelName = "";  // name of the model for the toString method, so it can be identified
-    UnitTypeTable utt = null;
+    UnitTypeTable utt;
     
     
     public UnitActionProbabilityDistributionAI(UnitTypeTable utt) throws Exception {

--- a/src/ai/stochastic/UnitActionTypeConstantDistribution.java
+++ b/src/ai/stochastic/UnitActionTypeConstantDistribution.java
@@ -17,7 +17,7 @@ import rts.units.UnitTypeTable;
  */
 public class UnitActionTypeConstantDistribution extends UnitActionProbabilityDistribution {
 
-    double m_distribution[] = null;
+    double m_distribution[];
     
     public UnitActionTypeConstantDistribution(UnitTypeTable a_utt, double distribution[]) throws Exception {
         super(a_utt);

--- a/src/gui/JTextAreaWriter.java
+++ b/src/gui/JTextAreaWriter.java
@@ -15,7 +15,7 @@ import javax.swing.JTextArea;
  */
 public class JTextAreaWriter extends Writer {
 
-    JTextArea m_ta = null;
+    JTextArea m_ta;
     
     public JTextAreaWriter(JTextArea ta) {
         m_ta = ta;

--- a/src/gui/MouseController.java
+++ b/src/gui/MouseController.java
@@ -35,8 +35,8 @@ import rts.units.Unit;
  *        space, the selected worker will go and build a building in the desired place.
  */
 public class MouseController extends AbstractionLayerAI {
-    PhysicalGameStateMouseJFrame m_frame = null;
-    PGSMouseListener m_mouseListener = null;
+    PhysicalGameStateMouseJFrame m_frame;
+    PGSMouseListener m_mouseListener;
     
     public MouseController(PhysicalGameStateMouseJFrame frame) {
         super(new BFSPathFinding());

--- a/src/gui/PGSMouseListener.java
+++ b/src/gui/PGSMouseListener.java
@@ -23,13 +23,13 @@ import util.Pair;
  * @author santi
  */
 public class PGSMouseListener implements MouseListener, MouseMotionListener, KeyListener {
-    MouseController AI = null;
-    PhysicalGameStateMouseJFrame frame = null;
-    GameState gs = null;
+    MouseController AI;
+    PhysicalGameStateMouseJFrame frame;
+    GameState gs;
     int playerID = -1;
     
     List<Unit> selectedUnits = new ArrayList<>();
-    String selectedButton = null;
+    String selectedButton;
 
     HashMap<Character,String> unitTypeQuickKeys = new HashMap<>();
     

--- a/src/gui/PhysicalGameStateJFrame.java
+++ b/src/gui/PhysicalGameStateJFrame.java
@@ -12,7 +12,7 @@ import rts.GameState;
  * @author santi
  */
 public class PhysicalGameStateJFrame extends JFrame {
-    PhysicalGameStatePanel panel = null;
+    PhysicalGameStatePanel panel;
     
     public PhysicalGameStateJFrame(String title, int dx, int dy, PhysicalGameStatePanel a_panel) {
         super(title);

--- a/src/gui/PhysicalGameStateMouseJFrame.java
+++ b/src/gui/PhysicalGameStateMouseJFrame.java
@@ -17,8 +17,8 @@ import util.Pair;
  * @author santi
  */
 public class PhysicalGameStateMouseJFrame extends JFrame {
-    PhysicalGameStatePanel panel = null;
-    MouseControllerPanel mousePanel = null;
+    PhysicalGameStatePanel panel;
+    MouseControllerPanel mousePanel;
         
     public PhysicalGameStateMouseJFrame(String title, int dx, int dy, PhysicalGameStatePanel a_panel) {
         super(title);

--- a/src/gui/PhysicalGameStatePanel.java
+++ b/src/gui/PhysicalGameStatePanel.java
@@ -33,12 +33,12 @@ public class PhysicalGameStatePanel extends JPanel {
 
     boolean fullObservability = true;
     int drawFromPerspectiveOfPlayer = -1;   // if fullObservability is false, and this is 0 or 1, it only draws what the specified player can see
-    GameState gs = null;
+    GameState gs;
 
     // Units to be highlighted (this is used, for example, by the MouseController,
     // to give feedback to the human, on which units are selectable.
     List<Unit> toHighLight = new LinkedList<>();
-    EvaluationFunction evalFunction = null;
+    EvaluationFunction evalFunction;
 
     // area to highlight: this can be used to highlight a rectangle of the game:
     int m_mouse_selection_x0 = -1;

--- a/src/gui/TraceVisualizer.java
+++ b/src/gui/TraceVisualizer.java
@@ -23,10 +23,10 @@ import util.Pair;
  */
 public class TraceVisualizer extends JPanel implements ListSelectionListener {
     int current_step = 0;
-    Trace trace = null;
+    Trace trace;
 
-    JPanel statePanel = null;
-    JList Selector = null;
+    JPanel statePanel;
+    JList Selector;
     List<GameState> states = new LinkedList<>();
 
     public static JFrame newWindow(String name,int dx,int dy,Trace t, int subjectID) throws Exception {

--- a/src/gui/frontend/FEStateMouseListener.java
+++ b/src/gui/frontend/FEStateMouseListener.java
@@ -18,7 +18,7 @@ import util.Pair;
  * @author santi
  */
 public class FEStateMouseListener implements MouseListener, MouseMotionListener {
-    PhysicalGameStatePanel panel = null;
+    PhysicalGameStatePanel panel;
     UnitTypeTable utt;
     
     public FEStateMouseListener(PhysicalGameStatePanel a_panel, UnitTypeTable a_utt) {

--- a/src/gui/frontend/FEStatePane.java
+++ b/src/gui/frontend/FEStatePane.java
@@ -112,9 +112,9 @@ import ai.scv.SCV;
  * @author santi
  */
 public class FEStatePane extends JPanel {
-    PhysicalGameStatePanel statePanel = null;
-    JTextArea textArea = null;
-    UnitTypeTable currentUtt = null;
+    PhysicalGameStatePanel statePanel;
+    JTextArea textArea;
+    UnitTypeTable currentUtt;
 
     JFileChooser fileChooser = new JFileChooser();
 
@@ -199,14 +199,14 @@ public class FEStatePane extends JPanel {
                                    "Nondeterministic-Alternating",
                                    "Nondeterministic-Random"};
 
-    JFormattedTextField mapWidthField = null;
-    JFormattedTextField mapHeightField = null;
-    JFormattedTextField maxCyclesField = null;
-    JFormattedTextField defaultDelayField = null;
-    JCheckBox fullObservabilityBox = null;
-    JComboBox unitTypeTableBox = null;
-    JCheckBox saveTraceBox = null;
-    JCheckBox slowDownBox = null;    
+    JFormattedTextField mapWidthField;
+    JFormattedTextField mapHeightField;
+    JFormattedTextField maxCyclesField;
+    JFormattedTextField defaultDelayField;
+    JCheckBox fullObservabilityBox;
+    JComboBox unitTypeTableBox;
+    JCheckBox saveTraceBox;
+    JCheckBox slowDownBox;
     
     JComboBox aiComboBox[] = {null,null};    
     JCheckBox continuingBox[] = {null,null};
@@ -214,7 +214,7 @@ public class FEStatePane extends JPanel {
     HashMap AIOptionsPanelComponents[] = {new HashMap<String, JComponent>(), new HashMap<String, JComponent>()};
     
     
-    FEStateMouseListener mouseListener = null;
+    FEStateMouseListener mouseListener;
 
     public FEStatePane() throws Exception {        
         currentUtt = new UnitTypeTable();

--- a/src/gui/frontend/FETournamentPane.java
+++ b/src/gui/frontend/FETournamentPane.java
@@ -47,35 +47,35 @@ public class FETournamentPane extends JPanel {
     public static final String TOURNAMENT_ROUNDROBIN = "Round Robin";
     public static final String TOURNAMENT_FIXED_OPPONENTS = "Fixed Opponents";
     
-    JComboBox tournamentTypeComboBox = null;
+    JComboBox tournamentTypeComboBox;
     
-    DefaultListModel availableAIsListModel = null;
-    JList availableAIsList = null;
-    DefaultListModel selectedAIsListModel = null;
-    JList selectedAIsList = null;
-    DefaultListModel opponentAIsListModel = null;
-    JList opponentAIsList = null;
-    JButton opponentAddButton = null;
-    JButton opponentRemoveButton = null;
+    DefaultListModel availableAIsListModel;
+    JList availableAIsList;
+    DefaultListModel selectedAIsListModel;
+    JList selectedAIsList;
+    DefaultListModel opponentAIsListModel;
+    JList opponentAIsList;
+    JButton opponentAddButton;
+    JButton opponentRemoveButton;
     
     JFileChooser mapFileChooser = new JFileChooser();
-    JList mapList = null;
-    DefaultListModel mapListModel = null;
+    JList mapList;
+    DefaultListModel mapListModel;
     
-    JFormattedTextField iterationsField = null;
-    JFormattedTextField maxGameLengthField = null;
-    JFormattedTextField timeBudgetField = null;
-    JFormattedTextField iterationsBudgetField = null;
-    JFormattedTextField preAnalysisTimeField = null;
+    JFormattedTextField iterationsField;
+    JFormattedTextField maxGameLengthField;
+    JFormattedTextField timeBudgetField;
+    JFormattedTextField iterationsBudgetField;
+    JFormattedTextField preAnalysisTimeField;
     
-    JComboBox unitTypeTableBox = null;
-    JCheckBox fullObservabilityCheckBox = null;
-    JCheckBox selfMatchesCheckBox = null;
-    JCheckBox timeoutCheckBox = null;
-    JCheckBox gcCheckBox = null;
-    JCheckBox tracesCheckBox = null;
+    JComboBox unitTypeTableBox;
+    JCheckBox fullObservabilityCheckBox;
+    JCheckBox selfMatchesCheckBox;
+    JCheckBox timeoutCheckBox;
+    JCheckBox gcCheckBox;
+    JCheckBox tracesCheckBox;
     
-    JTextArea tournamentProgressTextArea = null;
+    JTextArea tournamentProgressTextArea;
     
     JFileChooser fileChooser = new JFileChooser();    
     

--- a/src/gui/frontend/FETracePane.java
+++ b/src/gui/frontend/FETracePane.java
@@ -32,13 +32,13 @@ import util.XMLWriter;
  */
 public class FETracePane extends JPanel {
     
-    Trace currentTrace = null;
+    Trace currentTrace;
     int currentGameCycle = 0;
     
-    PhysicalGameStatePanel statePanel = null;
+    PhysicalGameStatePanel statePanel;
     
     JFileChooser fileChooser = new JFileChooser();
-    FEStatePane stateTab = null;
+    FEStatePane stateTab;
     
     public FETracePane(FEStatePane a_stateTab) {
         stateTab = a_stateTab;

--- a/src/rts/PhysicalGameState.java
+++ b/src/rts/PhysicalGameState.java
@@ -39,7 +39,7 @@ public class PhysicalGameState {
 
     int width = 8;
     int height = 8;
-    int terrain[] = null;
+    int terrain[];
     List<Player> players = new ArrayList<>();
     List<Unit> units = new LinkedList<>();
 

--- a/src/rts/PlayerActionGenerator.java
+++ b/src/rts/PlayerActionGenerator.java
@@ -18,11 +18,11 @@ public class PlayerActionGenerator {
     PhysicalGameState physicalGameState;
     ResourceUsage base_ru;
     List<Pair<Unit,List<UnitAction>>> choices;
-    PlayerAction lastAction = null;
+    PlayerAction lastAction;
     long size = 1;  // this will be capped at Long.MAX_VALUE;
     long generated = 0;
-    int choiceSizes[] = null;
-    int currentChoice[] = null;
+    int choiceSizes[];
+    int currentChoice[];
     boolean moreActions = true;
     
     /**

--- a/src/rts/Trace.java
+++ b/src/rts/Trace.java
@@ -28,7 +28,7 @@ import util.XMLWriter;
  */
 public class Trace {
 
-    UnitTypeTable utt = null;
+    UnitTypeTable utt;
     List<TraceEntry> entries = new LinkedList<>();
 
     /**
@@ -191,7 +191,7 @@ public class Trace {
     /**
      * this accelerates the function below if traversing a trace sequentially
      */
-    GameState getGameStateAtCycle_cache = null;
+    GameState getGameStateAtCycle_cache;
 
     /**
      * Simulates the game from the from the last cached cycle (initialized as

--- a/src/rts/TraceEntry.java
+++ b/src/rts/TraceEntry.java
@@ -17,7 +17,7 @@ import util.XMLWriter;
 public class TraceEntry {
 
     int time;
-    PhysicalGameState pgs = null;
+    PhysicalGameState pgs;
     List<Pair<Unit, UnitAction>> actions = new LinkedList<>();
 
     /**

--- a/src/rts/UnitAction.java
+++ b/src/rts/UnitAction.java
@@ -117,12 +117,12 @@ public class UnitAction {
     /**
      * UnitType associated with a 'produce' action
      */
-    UnitType unitType = null;
+    UnitType unitType;
 
     /**
      * Amount of resources associated with this action
      */
-    ResourceUsage r_cache = null;
+    ResourceUsage r_cache;
 
     /**
      * Creates an action with specified type

--- a/src/rts/units/UnitType.java
+++ b/src/rts/units/UnitType.java
@@ -25,7 +25,7 @@ public class UnitType {
     /**
      * The name of this type
      */
-    public String name = null;    		
+    public String name;
 
     /**
      * Cost to produce a unit of this type

--- a/src/tests/MapGenerator.java
+++ b/src/tests/MapGenerator.java
@@ -19,15 +19,15 @@ import util.XMLWriter;
  * 
  */
 public class MapGenerator {
-    static UnitTypeTable utt = null;
+    static UnitTypeTable utt;
     
-    UnitType resourceType = null;
-    UnitType baseType = null;
-    UnitType barracksType = null;
-    UnitType workerType = null;
-    UnitType lightType = null;
-    UnitType heavyType = null;
-    UnitType rangedType = null;
+    UnitType resourceType;
+    UnitType baseType;
+    UnitType barracksType;
+    UnitType workerType;
+    UnitType lightType;
+    UnitType heavyType;
+    UnitType rangedType;
     
     public MapGenerator(UnitTypeTable a_utt) {
         utt = a_utt;


### PR DESCRIPTION
This PR is a refactoring. There are 561 redundant variable initializations in the code, such as initializating integers, floats and doubles to 0, booleans to false and objects to null.

By analyzing these cases, I realized that the initialization of integers, floats, doubles and booleans could sometimes be informative to humans (e.g. flags to debug a class or change its behavior, albeit by hand), but initializing objects to null was always a redundant task.

Of the 561 redundant variable initializations in the code base, 279 where null object initializations in 86 files, which I have removed.