### PR TITLE
Add headless mode and update interval to config.properties

### DIFF
--- a/resources/config.properties
+++ b/resources/config.properties
@@ -4,7 +4,7 @@
 # CLIENT = Starts MicroRTS as a client instance.
 launch_mode=STANDALONE
 
-### NETWORKING ###
+################### NETWORKING ###################
 # Only needed if modes are SERVER/CLIENT
 # server_address=127.0.0.1
 # server_port=9898
@@ -18,9 +18,7 @@ constants_in_state=true
 # true to compress terrain information using run-length encoding, where
 # 0 = A and 1 = B, false to send the full binary data
 compress_terrain=false
-headless=false
-
-update_interval=5
+##################################################
 
 # MAP
 map_location=maps/16x16/basesWorkers16x16.xml
@@ -29,6 +27,14 @@ map_location=maps/16x16/basesWorkers16x16.xml
 
 # The max number of cycles the game will perform.
 max_cycles=5000
+
+# update interval, in milliseconds
+# ignored if headless == true
+update_interval=5
+
+# in headless mode, no window is drawn when running the game
+# the game also updates without intervals, which is much faster
+headless=false
 
 # If false, the players have full vision of the map.
 partially_observable=false

--- a/resources/config.properties
+++ b/resources/config.properties
@@ -18,6 +18,9 @@ constants_in_state=true
 # true to compress terrain information using run-length encoding, where
 # 0 = A and 1 = B, false to send the full binary data
 compress_terrain=false
+headless=false
+
+update_interval=5
 
 # MAP
 map_location=maps/16x16/basesWorkers16x16.xml

--- a/src/rts/Game.java
+++ b/src/rts/Game.java
@@ -1,0 +1,100 @@
+package rts;
+
+public class Game {
+
+    private rts.units.UnitTypeTable utt;
+    private rts.GameState gs;
+
+    private ai.core.AI ai1, ai2;
+
+    private boolean partiallyObservable, headless;
+    private int maxCycles, updateInterval;
+
+    public Game(rts.GameSettings gameSettings) throws Exception {
+        utt = new rts.units.UnitTypeTable(gameSettings.getUTTVersion(),
+            gameSettings.getConflictPolicy());
+        PhysicalGameState pgs = PhysicalGameState.load(gameSettings.getMapLocation(), utt);
+
+        gs = new GameState(pgs, utt);
+
+        partiallyObservable = gameSettings.isPartiallyObservable();
+        headless = gameSettings.isHeadless();
+        maxCycles = gameSettings.getMaxCycles();
+        updateInterval = gameSettings.getUpdateInterval();
+
+        java.lang.reflect.Constructor cons1 = Class.forName(gameSettings.getAI1())
+            .getConstructor(rts.units.UnitTypeTable.class);
+        ai1 = (ai.core.AI) cons1.newInstance(utt);
+        java.lang.reflect.Constructor cons2 = Class.forName(gameSettings.getAI2())
+            .getConstructor(rts.units.UnitTypeTable.class);
+        ai2 = (ai.core.AI) cons2.newInstance(utt);
+    }
+
+    public Game(rts.GameSettings gameSettings, ai.core.AI player_one, ai.core.AI player_two)
+        throws Exception {
+        utt = new rts.units.UnitTypeTable(gameSettings.getUTTVersion(),
+            gameSettings.getConflictPolicy());
+        PhysicalGameState pgs = PhysicalGameState.load(gameSettings.getMapLocation(), utt);
+
+        gs = new GameState(pgs, utt);
+
+        partiallyObservable = gameSettings.isPartiallyObservable();
+        headless = gameSettings.isHeadless();
+        maxCycles = gameSettings.getMaxCycles();
+        updateInterval = gameSettings.getUpdateInterval();
+
+        ai1=player_one;
+        ai2=player_two;
+    }
+
+    void start() throws Exception {
+        // Setup UI
+        javax.swing.JFrame w = headless ? null : gui.PhysicalGameStatePanel
+            .newVisualizer(gs, 640, 640, false, gui.PhysicalGameStatePanel.COLORSCHEME_BLACK);
+
+        start(w);
+    }
+
+    void start(javax.swing.JFrame w) throws Exception {
+        // Reset all players
+        ai1.reset();
+        ai2.reset();
+
+        // pre-game analysis
+        ai1.preGameAnalysis(gs, 0);
+        ai2.preGameAnalysis(gs, 0);
+
+        boolean gameover = false;
+        long nextTimeToUpdate = System.currentTimeMillis() + updateInterval;
+        do {
+            if (w == null || System.currentTimeMillis() >= nextTimeToUpdate) {
+                rts.GameState playerOneGameState =
+                    partiallyObservable ? new rts.PartiallyObservableGameState(gs, 0) : gs;
+                rts.GameState playerTwoGameState =
+                    partiallyObservable ? new rts.PartiallyObservableGameState(gs, 1) : gs;
+
+                rts.PlayerAction pa1 = ai1.getAction(0, playerOneGameState);
+                rts.PlayerAction pa2 = ai2.getAction(1, playerTwoGameState);
+                gs.issueSafe(pa1);
+                gs.issueSafe(pa2);
+
+                // simulate
+                gameover = gs.cycle();
+
+                if (w != null) {
+                    w.repaint();
+                }
+
+                nextTimeToUpdate += updateInterval;
+            } else {
+                try {
+                    Thread.sleep(1);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            }
+        } while (!gameover && gs.getTime() < maxCycles);
+        ai1.gameOver(gs.winner());
+        ai2.gameOver(gs.winner());
+    }
+}

--- a/src/rts/Game.java
+++ b/src/rts/Game.java
@@ -1,17 +1,23 @@
 package rts;
 
+import ai.core.AI;
+import gui.PhysicalGameStatePanel;
+import java.lang.reflect.Constructor;
+import javax.swing.JFrame;
+import rts.units.UnitTypeTable;
+
 public class Game {
 
-    private rts.units.UnitTypeTable utt;
+    private UnitTypeTable utt;
     private rts.GameState gs;
 
-    private ai.core.AI ai1, ai2;
+    private AI ai1, ai2;
 
     private boolean partiallyObservable, headless;
     private int maxCycles, updateInterval;
 
-    public Game(rts.GameSettings gameSettings) throws Exception {
-        utt = new rts.units.UnitTypeTable(gameSettings.getUTTVersion(),
+    public Game(GameSettings gameSettings) throws Exception {
+        utt = new UnitTypeTable(gameSettings.getUTTVersion(),
             gameSettings.getConflictPolicy());
         PhysicalGameState pgs = PhysicalGameState.load(gameSettings.getMapLocation(), utt);
 
@@ -22,17 +28,17 @@ public class Game {
         maxCycles = gameSettings.getMaxCycles();
         updateInterval = gameSettings.getUpdateInterval();
 
-        java.lang.reflect.Constructor cons1 = Class.forName(gameSettings.getAI1())
-            .getConstructor(rts.units.UnitTypeTable.class);
-        ai1 = (ai.core.AI) cons1.newInstance(utt);
-        java.lang.reflect.Constructor cons2 = Class.forName(gameSettings.getAI2())
-            .getConstructor(rts.units.UnitTypeTable.class);
-        ai2 = (ai.core.AI) cons2.newInstance(utt);
+        Constructor cons1 = Class.forName(gameSettings.getAI1())
+            .getConstructor(UnitTypeTable.class);
+        ai1 = (AI) cons1.newInstance(utt);
+        Constructor cons2 = Class.forName(gameSettings.getAI2())
+            .getConstructor(UnitTypeTable.class);
+        ai2 = (AI) cons2.newInstance(utt);
     }
 
-    public Game(rts.GameSettings gameSettings, ai.core.AI player_one, ai.core.AI player_two)
+    public Game(GameSettings gameSettings, AI player_one, AI player_two)
         throws Exception {
-        utt = new rts.units.UnitTypeTable(gameSettings.getUTTVersion(),
+        utt = new UnitTypeTable(gameSettings.getUTTVersion(),
             gameSettings.getConflictPolicy());
         PhysicalGameState pgs = PhysicalGameState.load(gameSettings.getMapLocation(), utt);
 
@@ -49,13 +55,13 @@ public class Game {
 
     void start() throws Exception {
         // Setup UI
-        javax.swing.JFrame w = headless ? null : gui.PhysicalGameStatePanel
-            .newVisualizer(gs, 640, 640, false, gui.PhysicalGameStatePanel.COLORSCHEME_BLACK);
+        JFrame w = headless ? null : PhysicalGameStatePanel
+            .newVisualizer(gs, 640, 640, false, PhysicalGameStatePanel.COLORSCHEME_BLACK);
 
         start(w);
     }
 
-    void start(javax.swing.JFrame w) throws Exception {
+    void start(JFrame w) throws Exception {
         // Reset all players
         ai1.reset();
         ai2.reset();
@@ -69,9 +75,9 @@ public class Game {
         do {
             if (w == null || System.currentTimeMillis() >= nextTimeToUpdate) {
                 rts.GameState playerOneGameState =
-                    partiallyObservable ? new rts.PartiallyObservableGameState(gs, 0) : gs;
+                    partiallyObservable ? new PartiallyObservableGameState(gs, 0) : gs;
                 rts.GameState playerTwoGameState =
-                    partiallyObservable ? new rts.PartiallyObservableGameState(gs, 1) : gs;
+                    partiallyObservable ? new PartiallyObservableGameState(gs, 1) : gs;
 
                 rts.PlayerAction pa1 = ai1.getAction(0, playerOneGameState);
                 rts.PlayerAction pa2 = ai2.getAction(1, playerTwoGameState);

--- a/src/rts/Game.java
+++ b/src/rts/Game.java
@@ -6,6 +6,11 @@ import java.lang.reflect.Constructor;
 import javax.swing.JFrame;
 import rts.units.UnitTypeTable;
 
+/**
+ * Class responsible for creating all objects necessary for a single game and
+ * run the main loop of the game until completion.
+ * @author douglasrizzo
+ */
 public class Game {
 
     private UnitTypeTable utt;
@@ -16,6 +21,12 @@ public class Game {
     private boolean partiallyObservable, headless;
     private int maxCycles, updateInterval;
 
+    /**
+     * Create a game from a GameSettings object.
+     * @param gameSettings a GameSettings object, created either by reading a config file or
+     *                     through command-ine arguments
+     * @throws Exception when reading the XML file for the map or instantiating AIs from class names
+     */
     public Game(GameSettings gameSettings) throws Exception {
         utt = new UnitTypeTable(gameSettings.getUTTVersion(),
             gameSettings.getConflictPolicy());
@@ -36,6 +47,14 @@ public class Game {
         ai2 = (AI) cons2.newInstance(utt);
     }
 
+    /**
+     * Create a game from a GameSettings object, but also receiving AI players as parameters
+     * @param gameSettings a GameSettings object, created either by reading a config file or
+     *                     through command-ine arguments
+     * @param player_one AI for player one
+     * @param player_two AI for player two
+     * @throws Exception when reading the XML file for the map
+     */
     public Game(GameSettings gameSettings, AI player_one, AI player_two)
         throws Exception {
         utt = new UnitTypeTable(gameSettings.getUTTVersion(),
@@ -53,6 +72,10 @@ public class Game {
         ai2=player_two;
     }
 
+    /**
+     * run the main loop of the game
+     * @throws Exception
+     */
     void start() throws Exception {
         // Setup UI
         JFrame w = headless ? null : PhysicalGameStatePanel
@@ -61,6 +84,11 @@ public class Game {
         start(w);
     }
 
+    /**
+     * run the main loop of the game
+     * @param w a window where the game will be displayed
+     * @throws Exception
+     */
     void start(JFrame w) throws Exception {
         // Reset all players
         ai1.reset();

--- a/src/rts/GameSettings.java
+++ b/src/rts/GameSettings.java
@@ -138,7 +138,8 @@ public class GameSettings {
      * --serialization: serialization type (1 for XML, 2 for JSON)
      * -m: path for the map file
      * -c: max cycles
-     * -h: headless
+     * -i: update interval between each tick, in milliseconds
+     * -h: headless: 1 or true, 0 or false
      * --partially_observable: 1 or true, 0 or false
      * --ai1: name of the class to be instantiated for player 1
      * --ai2: name of the class to be instantiated for player 2
@@ -170,7 +171,7 @@ public class GameSettings {
                 case "-i":
                     updateInterval = Integer.parseInt(args[i]);
                     break;
-                case "-h":
+                case "--headless":
                     headless = Boolean.parseBoolean(args[i]);
                     break;
                 case "--partially_observable":
@@ -179,7 +180,7 @@ public class GameSettings {
                 case "-u":
                     uttVersion = Integer.parseInt(args[i]);
                     break;
-                case "-conflict_policy":
+                case "--conflict_policy":
                     conflictPolicy = Integer.parseInt(args[i]);
                     break;
                 case "--ai1":

--- a/src/rts/GameSettings.java
+++ b/src/rts/GameSettings.java
@@ -26,31 +26,36 @@ public class GameSettings {
 
     // Game settings
     private int maxCycles = 5000;
+    private int updateInterval = 20;
     private boolean partiallyObservable = false;
     private int uttVersion = 1;
     private int conflictPolicy = 1;
 
     private boolean includeConstantsInState = true, compressTerrain = false;
+    private boolean headless = false;
 
     // Opponents:
     private String AI1 = "";
     private String AI2 = "";
 
     public GameSettings(LaunchMode launchMode, String serverAddress, int serverPort,
-        int serializationType, String mapLocation, int maxCycles, boolean partiallyObservable,
-        int uttVersion, int confictPolicy, boolean includeConstantsInState, boolean compressTerrain,
-        String AI1, String AI2) {
+        int serializationType, String mapLocation, int maxCycles, int updateInterval,
+        boolean partiallyObservable, int uttVersion, int confictPolicy,
+        boolean includeConstantsInState, boolean compressTerrain, boolean headless, String AI1,
+        String AI2) {
         this.launchMode = launchMode;
         this.serverAddress = serverAddress;
         this.serverPort = serverPort;
         this.serializationType = serializationType;
         this.mapLocation = mapLocation;
         this.maxCycles = maxCycles;
+        this.updateInterval = updateInterval;
         this.partiallyObservable = partiallyObservable;
         this.uttVersion = uttVersion;
         this.conflictPolicy = confictPolicy;
         this.includeConstantsInState = includeConstantsInState;
         this.compressTerrain = compressTerrain;
+        this.headless = headless;
         this.AI1 = AI1;
         this.AI2 = AI2;
     }
@@ -73,6 +78,10 @@ public class GameSettings {
 
     public int getMaxCycles() {
         return maxCycles;
+    }
+
+    public int getUpdateInterval() {
+        return updateInterval;
     }
 
     public boolean isPartiallyObservable() {
@@ -107,6 +116,10 @@ public class GameSettings {
         return compressTerrain;
     }
 
+    public boolean isHeadless() {
+        return headless;
+    }
+
     /**
      * Create a GameSettings object from a list of command-line arguments
      * @param args a String array containing command-line arguments
@@ -125,6 +138,7 @@ public class GameSettings {
      * --serialization: serialization type (1 for XML, 2 for JSON)
      * -m: path for the map file
      * -c: max cycles
+     * -h: headless
      * --partially_observable: 1 or true, 0 or false
      * --ai1: name of the class to be instantiated for player 1
      * --ai2: name of the class to be instantiated for player 2
@@ -152,6 +166,12 @@ public class GameSettings {
                     break;
                 case "-c":
                     maxCycles = Integer.parseInt(args[i]);
+                    break;
+                case "-i":
+                    updateInterval = Integer.parseInt(args[i]);
+                    break;
+                case "-h":
+                    headless = Boolean.parseBoolean(args[i]);
                     break;
                 case "--partially_observable":
                     partiallyObservable = Boolean.parseBoolean(args[i]);
@@ -210,18 +230,20 @@ public class GameSettings {
         int serializationType = readIntegerProperty(prop, "serialization_type", 2);
         String mapLocation = prop.getProperty("map_location");
         int maxCycles = readIntegerProperty(prop, "max_cycles", 5000);
+        int updateInterval = readIntegerProperty(prop, "update_interval", 20);
         boolean partiallyObservable = Boolean.parseBoolean(prop.getProperty("partially_observable"));
         int uttVersion = readIntegerProperty(prop, "UTT_version", 2);
         int conflictPolicy = readIntegerProperty(prop, "conflict_policy", 1);
         LaunchMode launchMode = LaunchMode.valueOf(prop.getProperty("launch_mode"));
         boolean includeConstantsInState = Boolean.parseBoolean(prop.getProperty("constants_in_state"));
         boolean compressTerrain = Boolean.parseBoolean(prop.getProperty("compress_terrain"));
+        boolean headless = Boolean.parseBoolean(prop.getProperty("headless"));
         String AI1 = prop.getProperty("AI1");
         String AI2 = prop.getProperty("AI2");
 
         return new GameSettings(launchMode, serverAddress, serverPort, serializationType,
-            mapLocation, maxCycles, partiallyObservable, uttVersion, conflictPolicy,
-            includeConstantsInState, compressTerrain, AI1, AI2);
+            mapLocation, maxCycles, updateInterval, partiallyObservable, uttVersion, conflictPolicy,
+            includeConstantsInState, compressTerrain, headless, AI1, AI2);
     }
     
     

--- a/src/rts/MicroRTS.java
+++ b/src/rts/MicroRTS.java
@@ -1,13 +1,8 @@
 package rts;
 
-import ai.core.AI;
-import gui.PhysicalGameStatePanel;
 import gui.frontend.FrontEnd;
-import java.lang.reflect.Constructor;
 import java.net.ServerSocket;
 import java.net.Socket;
-import javax.swing.JFrame;
-import rts.units.UnitTypeTable;
 
 /***
  * The main class for running a MicroRTS game. To modify existing settings change the file "config.properties".

--- a/src/rts/MicroRTS.java
+++ b/src/rts/MicroRTS.java
@@ -82,49 +82,6 @@ public class MicroRTS {
      * @throws Exception 
      */
     public static void runStandAloneGame(GameSettings gameSettings) throws Exception {
-        UnitTypeTable utt = new UnitTypeTable(gameSettings.getUTTVersion(), gameSettings.getConflictPolicy());
-        PhysicalGameState pgs = PhysicalGameState.load(gameSettings.getMapLocation(), utt);
-
-        GameState gs = new GameState(pgs, utt);
-        int PERIOD = 20;
-        boolean gameover = false;
-        
-        Constructor cons1 = Class.forName(gameSettings.getAI1()).getConstructor(UnitTypeTable.class);
-        AI ai1 = (AI)cons1.newInstance(utt);
-        Constructor cons2 = Class.forName(gameSettings.getAI2()).getConstructor(UnitTypeTable.class);
-        AI ai2 = (AI)cons2.newInstance(utt);
-
-        JFrame w = PhysicalGameStatePanel.newVisualizer(gs,640,640,gameSettings.isPartiallyObservable(),
-                                                        PhysicalGameStatePanel.COLORSCHEME_BLACK);
-
-        long nextTimeToUpdate = System.currentTimeMillis() + PERIOD;
-        do{
-            if (System.currentTimeMillis()>=nextTimeToUpdate) {
-                if (gameSettings.isPartiallyObservable()) {
-                    PlayerAction pa1 = ai1.getAction(0, new PartiallyObservableGameState(gs,0));
-                    PlayerAction pa2 = ai2.getAction(1, new PartiallyObservableGameState(gs,1));            
-                    gs.issueSafe(pa1);
-                    gs.issueSafe(pa2);
-                } else {
-                    PlayerAction pa1 = ai1.getAction(0, gs);
-                    PlayerAction pa2 = ai2.getAction(1, gs);
-                    gs.issueSafe(pa1);
-                    gs.issueSafe(pa2);
-                }
-
-                // simulate:
-                gameover = gs.cycle();
-                w.repaint();
-                nextTimeToUpdate+=PERIOD;
-            } else {
-                try {
-                    Thread.sleep(1);
-                } catch (Exception e) {
-                    e.printStackTrace();
-                }
-            }
-        }while(!gameover && gs.getTime()<gameSettings.getMaxCycles());
-        ai1.gameOver(gs.winner());
-        ai2.gameOver(gs.winner());        
-    }       
+        new Game(gameSettings).start();
+    }
 }

--- a/src/rts/RemoteGame.java
+++ b/src/rts/RemoteGame.java
@@ -2,35 +2,17 @@ package rts;
 
 import ai.core.AI;
 import ai.socket.SocketAI;
-import gui.PhysicalGameStatePanel;
 import java.net.Socket;
-import javax.swing.JFrame;
 import rts.units.UnitTypeTable;
 
-class RemoteGame extends Thread {
+class RemoteGame implements Runnable {
 
     private Socket socket;
-    private UnitTypeTable unitTypeTable;
-    private PhysicalGameState pgs;
-    private GameState gameState;
     private GameSettings gameSettings;
-    private boolean gameOver = false;
-
-    private static int PERIOD = 20;
-
 
     RemoteGame(Socket socket, GameSettings gameSettings) {
         this.socket = socket;
         this.gameSettings = gameSettings;
-
-        this.unitTypeTable = new UnitTypeTable(gameSettings.getUTTVersion(),gameSettings.getConflictPolicy());
-
-        try {
-            this.pgs = PhysicalGameState.load(gameSettings.getMapLocation(), unitTypeTable);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-        this.gameState = new GameState(pgs, unitTypeTable);
     }
 
     /**
@@ -39,6 +21,9 @@ class RemoteGame extends Thread {
     @Override
     public void run() {
         try {
+            rts.units.UnitTypeTable unitTypeTable = new rts.units.UnitTypeTable(
+                gameSettings.getUTTVersion(), gameSettings.getConflictPolicy());
+
             // Generate players
             // player 1 is created from SocketAI
             AI player_one = SocketAI.createFromExistingSocket(100, 0, unitTypeTable,
@@ -49,50 +34,10 @@ class RemoteGame extends Thread {
                 .getConstructor(UnitTypeTable.class);
             AI player_two = (AI) cons2.newInstance(unitTypeTable);
 
-            // Reset all players
-            player_one.reset();
-            player_two.reset();
-
-            // allow for pre-game analysis
-            player_one.preGameAnalysis(gameState,0);
-            player_two.preGameAnalysis(gameState,0);
-
-            // Setup UI
-            JFrame w = PhysicalGameStatePanel.newVisualizer(gameState,640, 640, false, PhysicalGameStatePanel.COLORSCHEME_BLACK);
-
-            long nextTimeToUpdate = System.currentTimeMillis() + PERIOD;
-            do {
-                if (System.currentTimeMillis() >= nextTimeToUpdate) {
-
-                    GameState playerOneGameState = gameSettings.isPartiallyObservable() ? new PartiallyObservableGameState(gameState,0) : gameState;
-                    GameState playerTwoGameState = gameSettings.isPartiallyObservable() ? new PartiallyObservableGameState(gameState,1) : gameState;
-
-                    PlayerAction pa1 = player_one.getAction(0, playerOneGameState);
-                    PlayerAction pa2 = player_two.getAction(1, playerTwoGameState);
-
-                    gameState.issueSafe(pa1);
-                    gameState.issueSafe(pa2);
-
-                    // simulate:
-                    gameOver = gameState.cycle();
-
-                    w.repaint();
-                    nextTimeToUpdate += PERIOD;
-                } else {
-                    try {
-                        Thread.sleep(1);
-                    } catch (Exception e) {
-                        e.printStackTrace();
-                    }
-                }
-            } while (!gameOver && gameState.getTime() < gameSettings.getMaxCycles());
-            player_one.gameOver(gameState.winner());
-            player_two.gameOver(gameState.winner());
-        } catch ( Exception e ) {
+            Game game = new Game(gameSettings, player_one, player_two);
+            game.start();
+        } catch (Exception e) {
             e.printStackTrace();
         }
     }
 }
-
-
-

--- a/src/rts/RemoteGame.java
+++ b/src/rts/RemoteGame.java
@@ -2,6 +2,7 @@ package rts;
 
 import ai.core.AI;
 import ai.socket.SocketAI;
+import java.lang.reflect.Constructor;
 import java.net.Socket;
 import rts.units.UnitTypeTable;
 
@@ -21,7 +22,7 @@ class RemoteGame implements Runnable {
     @Override
     public void run() {
         try {
-            rts.units.UnitTypeTable unitTypeTable = new rts.units.UnitTypeTable(
+            UnitTypeTable unitTypeTable = new UnitTypeTable(
                 gameSettings.getUTTVersion(), gameSettings.getConflictPolicy());
 
             // Generate players
@@ -30,7 +31,7 @@ class RemoteGame implements Runnable {
                 gameSettings.getSerializationType(), gameSettings.isIncludeConstantsInState(),
                 gameSettings.isCompressTerrain(), socket);
             // player 2 is created using the info from gameSettings
-            java.lang.reflect.Constructor cons2 = Class.forName(gameSettings.getAI2())
+            Constructor cons2 = Class.forName(gameSettings.getAI2())
                 .getConstructor(UnitTypeTable.class);
             AI player_two = (AI) cons2.newInstance(unitTypeTable);
 


### PR DESCRIPTION
In this PR, I allow users to select the update interval (the wait time between game ticks) they want for both a standalone and remote game, by exposing the `PERIOD` variable from both `RemoteGame` and `MicroRTS` classes.

A very small update interval can make the game end almost immediately. This is valuable in cases where users are working with machine/reinforcement learning agents and are collecting training examples, or in case they just want to gather the outcome of many games and time is of the essence.

Since there is no point in expectating a very fast game, I have also devised a way to run both standalone and remote games without opening a JFrame and repainting it at every tick. This is done with another property in the config file.

Lastly, since both the standalone and remote games have many similarities in the way they create a game and run its main loop, I have created a single `Game` class which both `MicroRTS` and `RemoteGame` make use of. This class reads the config file, creates all necessary objects to run a single game and runs the main loop until completion.

The `Game` class may alternatively receive a JFrame as an argument, allowing a single window to be reused by multiple games played in succession.