### PR TITLE
Use game class

### DIFF
--- a/src/ai/socket/GameVisualSimulationWithSocketAI.java
+++ b/src/ai/socket/GameVisualSimulationWithSocketAI.java
@@ -8,6 +8,8 @@ import ai.core.AI;
 import ai.*;
 import gui.PhysicalGameStatePanel;
 import javax.swing.JFrame;
+
+import rts.Game;
 import rts.GameState;
 import rts.PhysicalGameState;
 import rts.PlayerAction;
@@ -20,48 +22,12 @@ import rts.units.UnitTypeTable;
 public class GameVisualSimulationWithSocketAI {
     public static void main(String args[]) throws Exception {
         UnitTypeTable utt = new UnitTypeTable();
-        PhysicalGameState pgs = PhysicalGameState.load("maps/16x16/basesWorkers16x16.xml", utt);
-//        PhysicalGameState pgs = MapGenerator.basesWorkers8x8Obstacle();
-
-        GameState gs = new GameState(pgs, utt);
-        int MAXCYCLES = 5000;
-        int PERIOD = 20;
-        boolean gameover = false;
         
-//        AI ai1 = new WorkerRush(utt, new BFSPathFinding());        
         AI ai1 = new SocketAI(100,0, "127.0.0.1", 9898, SocketAI.LANGUAGE_XML, utt);
-//        AI ai1 = new SocketAI(100,0, "127.0.0.1", 9898, SocketAI.LANGUAGE_JSON, utt);
         AI ai2 = new RandomBiasedAI();
-        
-        ai1.reset();
-        ai2.reset();
 
-        JFrame w = PhysicalGameStatePanel.newVisualizer(gs,640,640,false,PhysicalGameStatePanel.COLORSCHEME_BLACK);
-//        JFrame w = PhysicalGameStatePanel.newVisualizer(gs,640,640,false,PhysicalGameStatePanel.COLORSCHEME_WHITE);
-
-        ai1.preGameAnalysis(gs, 1000, ".");
-        ai2.preGameAnalysis(gs, 1000, ".");
-
-        long nextTimeToUpdate = System.currentTimeMillis() + PERIOD;
-        do{
-            if (System.currentTimeMillis()>=nextTimeToUpdate) {
-                PlayerAction pa1 = ai1.getAction(0, gs);
-                PlayerAction pa2 = ai2.getAction(1, gs);
-                gs.issueSafe(pa1);
-                gs.issueSafe(pa2);
-
-                // simulate:
-                gameover = gs.cycle();
-                w.repaint();
-                nextTimeToUpdate+=PERIOD;
-            } else {
-                try {
-                    Thread.sleep(1);
-                } catch (Exception e) {
-                    e.printStackTrace();
-                }
-            }
-        }while(!gameover && gs.getTime()<MAXCYCLES);
+        Game game = new Game( utt, "maps/16x16/basesWorkers16x16.xml", false, false, 5000, 20, ai1, ai2);
+        game.start();
         
         System.out.println("Game Over");
     }    

--- a/src/gui/frontend/FEStatePane.java
+++ b/src/gui/frontend/FEStatePane.java
@@ -630,16 +630,10 @@ public class FEStatePane extends JPanel {
                                             
 //                                            System.out.println("----------------------------------------");
 //                                            System.out.println(gs);
-                                            
-                                            PlayerAction pa1 = null;
-                                            PlayerAction pa2 = null;
-                                            if (fullObservabilityBox.isSelected()) {
-                                                pa1 = ai1.getAction(0, gs);
-                                                pa2 = ai2.getAction(1, gs);
-                                            } else {
-                                                pa1 = ai1.getAction(0, new PartiallyObservableGameState(gs,0));
-                                                pa2 = ai2.getAction(1, new PartiallyObservableGameState(gs,1));
-                                            }
+
+                                            PlayerAction pa1 = ai1.getAction(0, fullObservabilityBox.isSelected() ? gs : new PartiallyObservableGameState(gs, 0));
+                                            PlayerAction pa2 = ai2.getAction(1, fullObservabilityBox.isSelected() ? gs : new PartiallyObservableGameState(gs, 0));
+
                                             if (trace!=null && (!pa1.isEmpty() || !pa2.isEmpty())) {
 //                                                System.out.println("- (for trace) ---------------------------------------");
 //                                                System.out.println(gs);

--- a/src/rts/Game.java
+++ b/src/rts/Game.java
@@ -4,6 +4,7 @@ import ai.core.AI;
 import gui.PhysicalGameStatePanel;
 import java.lang.reflect.Constructor;
 import javax.swing.JFrame;
+
 import rts.units.UnitTypeTable;
 
 /**
@@ -12,11 +13,8 @@ import rts.units.UnitTypeTable;
  * @author douglasrizzo
  */
 public class Game {
-
-    private UnitTypeTable utt;
-    private rts.GameState gs;
-
-    private AI ai1, ai2;
+    protected rts.GameState gs;
+    protected AI ai1, ai2;
 
     private boolean partiallyObservable, headless;
     private int maxCycles, updateInterval;
@@ -48,7 +46,6 @@ public class Game {
 
         this.ai1 = (AI) cons1.newInstance(utt);
         this.ai2 = (AI) cons2.newInstance(utt);
-
     }
 
     public Game(UnitTypeTable utt, String mapLocation, boolean headless, boolean partiallyObservable, int maxCycles,
@@ -61,8 +58,6 @@ public class Game {
 
     private Game(UnitTypeTable utt, String mapLocation, boolean headless, boolean partiallyObservable, int maxCycles,
                  int updateInterval) throws Exception {
-
-        this.utt = utt;
 
         PhysicalGameState pgs = PhysicalGameState.load(mapLocation, utt);
 
@@ -83,7 +78,7 @@ public class Game {
      */
     public Game(GameSettings gameSettings, AI player_one, AI player_two)
         throws Exception {
-        utt = new UnitTypeTable(gameSettings.getUTTVersion(),
+        UnitTypeTable utt = new UnitTypeTable(gameSettings.getUTTVersion(),
             gameSettings.getConflictPolicy());
         PhysicalGameState pgs = PhysicalGameState.load(gameSettings.getMapLocation(), utt);
 

--- a/src/rts/Game.java
+++ b/src/rts/Game.java
@@ -23,28 +23,54 @@ public class Game {
 
     /**
      * Create a game from a GameSettings object.
+     *
      * @param gameSettings a GameSettings object, created either by reading a config file or
      *                     through command-ine arguments
      * @throws Exception when reading the XML file for the map or instantiating AIs from class names
      */
     public Game(GameSettings gameSettings) throws Exception {
-        utt = new UnitTypeTable(gameSettings.getUTTVersion(),
-            gameSettings.getConflictPolicy());
-        PhysicalGameState pgs = PhysicalGameState.load(gameSettings.getMapLocation(), utt);
+        this(new UnitTypeTable(gameSettings.getUTTVersion(),
+                        gameSettings.getConflictPolicy()), gameSettings.getMapLocation(),
+                gameSettings.isHeadless(),
+                gameSettings.isPartiallyObservable(), gameSettings.getMaxCycles(), gameSettings.getUpdateInterval(),
+                gameSettings.getAI1(), gameSettings.getAI2());
+    }
+
+
+    public Game(UnitTypeTable utt, String mapLocation, boolean headless, boolean partiallyObservable, int maxCycles,
+                int updateInterval, String ai1, String ai2) throws Exception {
+        this(utt, mapLocation, headless, partiallyObservable, maxCycles, updateInterval);
+
+        Constructor cons1 = Class.forName(ai1)
+                .getConstructor(UnitTypeTable.class);
+        Constructor cons2 = Class.forName(ai2)
+                .getConstructor(UnitTypeTable.class);
+
+        this.ai1 = (AI) cons1.newInstance(utt);
+        this.ai2 = (AI) cons2.newInstance(utt);
+
+    }
+
+    public Game(UnitTypeTable utt, String mapLocation, boolean headless, boolean partiallyObservable, int maxCycles,
+                int updateInterval, AI ai1, AI ai2) throws Exception {
+        this(utt, mapLocation, headless, partiallyObservable, maxCycles, updateInterval);
+
+        this.ai1 = ai1;
+        this.ai2 = ai2;
+    }
+
+    private Game(UnitTypeTable utt, String mapLocation, boolean headless, boolean partiallyObservable, int maxCycles,
+                 int updateInterval) throws Exception {
+
+        this.utt = utt;
+
+        PhysicalGameState pgs = PhysicalGameState.load(mapLocation, utt);
 
         gs = new GameState(pgs, utt);
-
-        partiallyObservable = gameSettings.isPartiallyObservable();
-        headless = gameSettings.isHeadless();
-        maxCycles = gameSettings.getMaxCycles();
-        updateInterval = gameSettings.getUpdateInterval();
-
-        Constructor cons1 = Class.forName(gameSettings.getAI1())
-            .getConstructor(UnitTypeTable.class);
-        ai1 = (AI) cons1.newInstance(utt);
-        Constructor cons2 = Class.forName(gameSettings.getAI2())
-            .getConstructor(UnitTypeTable.class);
-        ai2 = (AI) cons2.newInstance(utt);
+        this.partiallyObservable = partiallyObservable;
+        this.headless = headless;
+        this.maxCycles = maxCycles;
+        this.updateInterval = updateInterval;
     }
 
     /**

--- a/src/rts/Game.java
+++ b/src/rts/Game.java
@@ -102,7 +102,7 @@ public class Game {
      * run the main loop of the game
      * @throws Exception
      */
-    void start() throws Exception {
+    public void start() throws Exception {
         // Setup UI
         JFrame w = headless ? null : PhysicalGameStatePanel
             .newVisualizer(gs, 640, 640, false, PhysicalGameStatePanel.COLORSCHEME_BLACK);
@@ -115,7 +115,7 @@ public class Game {
      * @param w a window where the game will be displayed
      * @throws Exception
      */
-    void start(JFrame w) throws Exception {
+    public void start(JFrame w) throws Exception {
         // Reset all players
         ai1.reset();
         ai2.reset();

--- a/src/rts/Game.java
+++ b/src/rts/Game.java
@@ -125,35 +125,33 @@ public class Game {
         ai2.preGameAnalysis(gs, 0);
 
         boolean gameover = false;
-        long nextTimeToUpdate = System.currentTimeMillis() + updateInterval;
-        do {
-            if (w == null || System.currentTimeMillis() >= nextTimeToUpdate) {
-                rts.GameState playerOneGameState =
+        while (!gameover && gs.getTime() < maxCycles) {
+            rts.GameState playerOneGameState =
                     partiallyObservable ? new PartiallyObservableGameState(gs, 0) : gs;
-                rts.GameState playerTwoGameState =
+            rts.GameState playerTwoGameState =
                     partiallyObservable ? new PartiallyObservableGameState(gs, 1) : gs;
 
-                rts.PlayerAction pa1 = ai1.getAction(0, playerOneGameState);
-                rts.PlayerAction pa2 = ai2.getAction(1, playerTwoGameState);
-                gs.issueSafe(pa1);
-                gs.issueSafe(pa2);
+            rts.PlayerAction pa1 = ai1.getAction(0, playerOneGameState);
+            rts.PlayerAction pa2 = ai2.getAction(1, playerTwoGameState);
+            gs.issueSafe(pa1);
+            gs.issueSafe(pa2);
 
-                // simulate
-                gameover = gs.cycle();
+            // simulate
+            gameover = gs.cycle();
 
-                if (w != null) {
+            if (w != null) {
+                if (!w.isVisible())
+                    break;
+                if (updateInterval > 0) {
                     w.repaint();
-                }
-
-                nextTimeToUpdate += updateInterval;
-            } else {
-                try {
-                    Thread.sleep(1);
-                } catch (Exception e) {
-                    e.printStackTrace();
+                    try {
+                        Thread.sleep(updateInterval);
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    }
                 }
             }
-        } while (!gameover && gs.getTime() < maxCycles);
+        }
         ai1.gameOver(gs.winner());
         ai2.gameOver(gs.winner());
     }

--- a/src/rts/Game.java
+++ b/src/rts/Game.java
@@ -35,8 +35,8 @@ public class Game {
     }
 
 
-    public Game(UnitTypeTable utt, String mapLocation, boolean headless, boolean partiallyObservable, int maxCycles,
-                int updateInterval, String ai1, String ai2) throws Exception {
+    private Game(UnitTypeTable utt, String mapLocation, boolean headless, boolean partiallyObservable, int maxCycles,
+                 int updateInterval, String ai1, String ai2) throws Exception {
         this(utt, mapLocation, headless, partiallyObservable, maxCycles, updateInterval);
 
         Constructor cons1 = Class.forName(ai1)
@@ -56,12 +56,15 @@ public class Game {
         this.ai2 = ai2;
     }
 
-    private Game(UnitTypeTable utt, String mapLocation, boolean headless, boolean partiallyObservable, int maxCycles,
-                 int updateInterval) throws Exception {
-
+    protected Game(UnitTypeTable utt, String mapLocation, boolean headless, boolean partiallyObservable, int maxCycles,
+                   int updateInterval) throws Exception {
+        this(headless, partiallyObservable, maxCycles, updateInterval);
         PhysicalGameState pgs = PhysicalGameState.load(mapLocation, utt);
-
         gs = new GameState(pgs, utt);
+    }
+
+    private Game(boolean headless, boolean partiallyObservable, int maxCycles,
+                 int updateInterval) {
         this.partiallyObservable = partiallyObservable;
         this.headless = headless;
         this.maxCycles = maxCycles;

--- a/src/rts/MouseGame.java
+++ b/src/rts/MouseGame.java
@@ -1,0 +1,29 @@
+package rts;
+
+import ai.core.AI;
+import gui.MouseController;
+import gui.PhysicalGameStateMouseJFrame;
+import gui.PhysicalGameStatePanel;
+import rts.units.UnitTypeTable;
+
+import java.lang.reflect.Constructor;
+
+public class MouseGame extends Game {
+
+    private PhysicalGameStateMouseJFrame w;
+
+    public MouseGame(UnitTypeTable utt, String mapLocation, boolean headless, boolean partiallyObservable, int maxCycles, int updateInterval, AI ai2) throws Exception {
+        super(utt, mapLocation, headless, partiallyObservable, maxCycles, updateInterval);
+        this.ai2 = ai2;
+
+        PhysicalGameStatePanel pgsp = new PhysicalGameStatePanel(gs);
+        w = new PhysicalGameStateMouseJFrame("Game State Visualizer (Mouse)", 640, 640, pgsp);
+
+        this.ai1 = new MouseController(w);
+    }
+
+    @Override
+    public void start() throws Exception {
+        super.start(w);
+    }
+}

--- a/src/rts/MouseGame.java
+++ b/src/rts/MouseGame.java
@@ -6,8 +6,6 @@ import gui.PhysicalGameStateMouseJFrame;
 import gui.PhysicalGameStatePanel;
 import rts.units.UnitTypeTable;
 
-import java.lang.reflect.Constructor;
-
 public class MouseGame extends Game {
 
     private PhysicalGameStateMouseJFrame w;

--- a/src/tests/GameVisualSimulationTest.java
+++ b/src/tests/GameVisualSimulationTest.java
@@ -11,6 +11,8 @@ import ai.abstraction.pathfinding.BFSPathFinding;
 import gui.PhysicalGameStatePanel;
 
 import javax.swing.JFrame;
+
+import rts.Game;
 import rts.GameState;
 import rts.PhysicalGameState;
 import rts.PlayerAction;
@@ -23,42 +25,11 @@ import rts.units.UnitTypeTable;
 public class GameVisualSimulationTest {
     public static void main(String[] args) throws Exception {
         UnitTypeTable utt = new UnitTypeTable();
-        PhysicalGameState pgs = PhysicalGameState.load("maps/16x16/basesWorkers16x16.xml", utt);
-//        PhysicalGameState pgs = MapGenerator.basesWorkers8x8Obstacle();
-
-        GameState gs = new GameState(pgs, utt);
-        int MAXCYCLES = 5000;
-        int PERIOD = 20;
-        boolean gameover = false;
-        
         AI ai1 = new WorkerRush(utt, new BFSPathFinding());        
         AI ai2 = new RandomBiasedAI();
 
-        JFrame w = PhysicalGameStatePanel.newVisualizer(gs,640,640,false,PhysicalGameStatePanel.COLORSCHEME_BLACK);
-//        JFrame w = PhysicalGameStatePanel.newVisualizer(gs,640,640,false,PhysicalGameStatePanel.COLORSCHEME_WHITE);
-
-        long nextTimeToUpdate = System.currentTimeMillis() + PERIOD;
-        do{
-            if (System.currentTimeMillis()>=nextTimeToUpdate) {
-                PlayerAction pa1 = ai1.getAction(0, gs);
-                PlayerAction pa2 = ai2.getAction(1, gs);
-                gs.issueSafe(pa1);
-                gs.issueSafe(pa2);
-
-                // simulate:
-                gameover = gs.cycle();
-                w.repaint();
-                nextTimeToUpdate+=PERIOD;
-            } else {
-                try {
-                    Thread.sleep(1);
-                } catch (Exception e) {
-                    e.printStackTrace();
-                }
-            }
-        }while(!gameover && gs.getTime()<MAXCYCLES);
-        ai1.gameOver(gs.winner());
-        ai2.gameOver(gs.winner());
+        Game game = new Game( utt, "maps/16x16/basesWorkers16x16.xml", false, false, 5000, 20, ai1, ai2);
+        game.start();
         
         System.out.println("Game Over");
     }    

--- a/src/tests/PlayGameWithMouseTest.java
+++ b/src/tests/PlayGameWithMouseTest.java
@@ -12,6 +12,7 @@ import ai.mcts.naivemcts.NaiveMCTS;
 import gui.MouseController;
 import gui.PhysicalGameStateMouseJFrame;
 import gui.PhysicalGameStatePanel;
+import rts.Game;
 import rts.GameState;
 import rts.PhysicalGameState;
 import rts.PlayerAction;
@@ -27,42 +28,15 @@ public class PlayGameWithMouseTest {
         PhysicalGameState pgs = PhysicalGameState.load("maps/16x16/basesWorkers16x16.xml", utt);
 
         GameState gs = new GameState(pgs, utt);
-        int MAXCYCLES = 10000;
         int PERIOD = 100;
-        boolean gameover = false;
-                
         PhysicalGameStatePanel pgsp = new PhysicalGameStatePanel(gs);
-        PhysicalGameStateMouseJFrame w = new PhysicalGameStateMouseJFrame("Game State Visuakizer (Mouse)",640,640,pgsp);
-//        PhysicalGameStateMouseJFrame w = new PhysicalGameStateMouseJFrame("Game State Visuakizer (Mouse)",400,400,pgsp);
+        PhysicalGameStateMouseJFrame w = new PhysicalGameStateMouseJFrame("Game State Visualizer (Mouse)",640,640, pgsp);
 
         AI ai1 = new MouseController(w);
-//        AI ai2 = new PassiveAI();
-//        AI ai2 = new RandomBiasedAI();
-//        AI ai2 = new LightRush(utt, new AStarPathFinding());
         AI ai2 = new ContinuingAI(new NaiveMCTS(PERIOD, -1, 100, 20, 0.33f, 0.0f, 0.75f, new RandomBiasedAI(), new SimpleEvaluationFunction(), true));
 
-        long nextTimeToUpdate = System.currentTimeMillis() + PERIOD;
-        do{
-            if (System.currentTimeMillis()>=nextTimeToUpdate) {
-                PlayerAction pa1 = ai1.getAction(0, gs);
-                PlayerAction pa2 = ai2.getAction(1, gs);
-                gs.issueSafe(pa1);
-                gs.issueSafe(pa2);
-
-                // simulate:
-                gameover = gs.cycle();
-                w.repaint();
-                nextTimeToUpdate+=PERIOD;
-            } else {
-                try {
-                    Thread.sleep(1);
-                } catch (InterruptedException e) {
-                    e.printStackTrace();
-                }
-            }
-        }while(!gameover && gs.getTime()<MAXCYCLES);
-        ai1.gameOver(gs.winner());
-        ai2.gameOver(gs.winner());
+        Game game = new Game( utt, "maps/16x16/basesWorkers16x16.xml", false, false, 5000, PERIOD, ai1, ai2);
+        game.start(w);
         
         System.out.println("Game Over");
     }    

--- a/src/tests/PlayGameWithMouseTest.java
+++ b/src/tests/PlayGameWithMouseTest.java
@@ -14,6 +14,7 @@ import gui.PhysicalGameStateMouseJFrame;
 import gui.PhysicalGameStatePanel;
 import rts.Game;
 import rts.GameState;
+import rts.MouseGame;
 import rts.PhysicalGameState;
 import rts.PlayerAction;
 import rts.units.UnitTypeTable;
@@ -24,19 +25,12 @@ import rts.units.UnitTypeTable;
  */
 public class PlayGameWithMouseTest {
     public static void main(String args[]) throws Exception {
-        UnitTypeTable utt = new UnitTypeTable();
-        PhysicalGameState pgs = PhysicalGameState.load("maps/16x16/basesWorkers16x16.xml", utt);
-
-        GameState gs = new GameState(pgs, utt);
         int PERIOD = 100;
-        PhysicalGameStatePanel pgsp = new PhysicalGameStatePanel(gs);
-        PhysicalGameStateMouseJFrame w = new PhysicalGameStateMouseJFrame("Game State Visualizer (Mouse)",640,640, pgsp);
 
-        AI ai1 = new MouseController(w);
-        AI ai2 = new ContinuingAI(new NaiveMCTS(PERIOD, -1, 100, 20, 0.33f, 0.0f, 0.75f, new RandomBiasedAI(), new SimpleEvaluationFunction(), true));
+        AI opponent = new ContinuingAI(new NaiveMCTS(PERIOD, -1, 100, 20, 0.33f, 0.0f, 0.75f, new RandomBiasedAI(), new SimpleEvaluationFunction(), true));
 
-        Game game = new Game( utt, "maps/16x16/basesWorkers16x16.xml", false, false, 5000, PERIOD, ai1, ai2);
-        game.start(w);
+        Game game = new MouseGame( new UnitTypeTable(), "maps/16x16/basesWorkers16x16.xml", false, false, 5000, PERIOD, opponent);
+        game.start();
         
         System.out.println("Game Over");
     }    

--- a/src/tests/sockets/RunClientExample.java
+++ b/src/tests/sockets/RunClientExample.java
@@ -9,6 +9,8 @@ import ai.*;
 import ai.socket.SocketAI;
 import gui.PhysicalGameStatePanel;
 import javax.swing.JFrame;
+
+import rts.Game;
 import rts.GameState;
 import rts.PhysicalGameState;
 import rts.PlayerAction;
@@ -28,50 +30,11 @@ import rts.units.UnitTypeTable;
  */
 public class RunClientExample {
     public static void main(String args[]) throws Exception {
-        String serverIP = "127.0.0.1";
-        int serverPort = 9898;
-        
-        
         UnitTypeTable utt = new UnitTypeTable();
-        PhysicalGameState pgs = PhysicalGameState.load("maps/16x16/basesWorkers16x16.xml", utt);
-
-        GameState gs = new GameState(pgs, utt);
-        int MAXCYCLES = 5000;
-        int PERIOD = 20;
-        boolean gameover = false;
-        
-//        SocketAI.DEBUG = 1;
-//        AI ai1 = new SocketAI(100,0, serverIP, serverPort, SocketAI.LANGUAGE_XML, utt);
-        AI ai1 = new SocketAI(100,0, serverIP, serverPort, SocketAI.LANGUAGE_JSON, utt);
-//        AI ai2 = new SocketAI(100,0, serverIP, serverPort, SocketAI.LANGUAGE_XML, utt);
+        AI ai1 = new SocketAI(100,0, "127.0.0.1", 9898, SocketAI.LANGUAGE_JSON, utt);
         AI ai2 = new RandomBiasedAI();
-        
-        ai1.reset();
-        ai2.reset();
 
-        JFrame w = PhysicalGameStatePanel.newVisualizer(gs,640,640,false,PhysicalGameStatePanel.COLORSCHEME_BLACK);
-
-        long nextTimeToUpdate = System.currentTimeMillis() + PERIOD;
-        do{
-            if (System.currentTimeMillis()>=nextTimeToUpdate) {
-                PlayerAction pa1 = ai1.getAction(0, gs);
-                PlayerAction pa2 = ai2.getAction(1, gs);
-                gs.issueSafe(pa1);
-                gs.issueSafe(pa2);
-
-                // simulate:
-                gameover = gs.cycle();
-                w.repaint();
-                nextTimeToUpdate+=PERIOD;
-            } else {
-                try {
-                    Thread.sleep(1);
-                } catch (Exception e) {
-                    e.printStackTrace();
-                }
-            }
-        }while(!gameover && gs.getTime()<MAXCYCLES);        
-        ai1.gameOver(gs.winner());
-        ai2.gameOver(gs.winner());
+        Game game = new Game( utt, "maps/16x16/basesWorkers16x16.xml", false, false, 5000, 20, ai1, ai2);
+        game.start();
     }    
 }


### PR DESCRIPTION
In this PR, I found multiple instances in the code where the main game loop was copy-pasted and replaced them with the creation of a `Game` object, introduced in #67, and a call to its `start()` method.

I also contribute a new class, `rts.MouseGame`, which inherits from `Game`, but uses a `PhysicalGameStateMouseJFrame` as its window instead of a `PhysicalGameStatePanel`