### PR TITLE
Fix conversion of Strings to boolean in CLI interface

### DIFF
--- a/src/rts/GameSettings.java
+++ b/src/rts/GameSettings.java
@@ -172,10 +172,10 @@ public class GameSettings {
                     updateInterval = Integer.parseInt(args[i]);
                     break;
                 case "--headless":
-                    headless = Boolean.parseBoolean(args[i]);
+                    headless = args[i].equals("1") || Boolean.parseBoolean(args[i]);
                     break;
                 case "--partially_observable":
-                    partiallyObservable = Boolean.parseBoolean(args[i]);
+                    partiallyObservable = args[i].equals("1") || Boolean.parseBoolean(args[i]);
                     break;
                 case "-u":
                     uttVersion = Integer.parseInt(args[i]);


### PR DESCRIPTION
I fixed the conversion of the String `"1"` to the boolean value `true` in the command-line interface. This is the described behavior in the docs, but it wasn't what was happening.