### PR TITLE
Game loop calls Thread.sleep() only once, if needed

### DIFF
--- a/src/rts/Game.java
+++ b/src/rts/Game.java
@@ -4,6 +4,7 @@ import ai.core.AI;
 import gui.PhysicalGameStatePanel;
 import java.lang.reflect.Constructor;
 import javax.swing.JFrame;
+
 import rts.units.UnitTypeTable;
 
 /**
@@ -12,11 +13,8 @@ import rts.units.UnitTypeTable;
  * @author douglasrizzo
  */
 public class Game {
-
-    private UnitTypeTable utt;
-    private rts.GameState gs;
-
-    private AI ai1, ai2;
+    protected rts.GameState gs;
+    protected AI ai1, ai2;
 
     private boolean partiallyObservable, headless;
     private int maxCycles, updateInterval;
@@ -48,7 +46,6 @@ public class Game {
 
         this.ai1 = (AI) cons1.newInstance(utt);
         this.ai2 = (AI) cons2.newInstance(utt);
-
     }
 
     public Game(UnitTypeTable utt, String mapLocation, boolean headless, boolean partiallyObservable, int maxCycles,
@@ -61,8 +58,6 @@ public class Game {
 
     private Game(UnitTypeTable utt, String mapLocation, boolean headless, boolean partiallyObservable, int maxCycles,
                  int updateInterval) throws Exception {
-
-        this.utt = utt;
 
         PhysicalGameState pgs = PhysicalGameState.load(mapLocation, utt);
 
@@ -83,7 +78,7 @@ public class Game {
      */
     public Game(GameSettings gameSettings, AI player_one, AI player_two)
         throws Exception {
-        utt = new UnitTypeTable(gameSettings.getUTTVersion(),
+        UnitTypeTable utt = new UnitTypeTable(gameSettings.getUTTVersion(),
             gameSettings.getConflictPolicy());
         PhysicalGameState pgs = PhysicalGameState.load(gameSettings.getMapLocation(), utt);
 

--- a/src/rts/Game.java
+++ b/src/rts/Game.java
@@ -23,28 +23,54 @@ public class Game {
 
     /**
      * Create a game from a GameSettings object.
+     *
      * @param gameSettings a GameSettings object, created either by reading a config file or
      *                     through command-ine arguments
      * @throws Exception when reading the XML file for the map or instantiating AIs from class names
      */
     public Game(GameSettings gameSettings) throws Exception {
-        utt = new UnitTypeTable(gameSettings.getUTTVersion(),
-            gameSettings.getConflictPolicy());
-        PhysicalGameState pgs = PhysicalGameState.load(gameSettings.getMapLocation(), utt);
+        this(new UnitTypeTable(gameSettings.getUTTVersion(),
+                        gameSettings.getConflictPolicy()), gameSettings.getMapLocation(),
+                gameSettings.isHeadless(),
+                gameSettings.isPartiallyObservable(), gameSettings.getMaxCycles(), gameSettings.getUpdateInterval(),
+                gameSettings.getAI1(), gameSettings.getAI2());
+    }
+
+
+    public Game(UnitTypeTable utt, String mapLocation, boolean headless, boolean partiallyObservable, int maxCycles,
+                int updateInterval, String ai1, String ai2) throws Exception {
+        this(utt, mapLocation, headless, partiallyObservable, maxCycles, updateInterval);
+
+        Constructor cons1 = Class.forName(ai1)
+                .getConstructor(UnitTypeTable.class);
+        Constructor cons2 = Class.forName(ai2)
+                .getConstructor(UnitTypeTable.class);
+
+        this.ai1 = (AI) cons1.newInstance(utt);
+        this.ai2 = (AI) cons2.newInstance(utt);
+
+    }
+
+    public Game(UnitTypeTable utt, String mapLocation, boolean headless, boolean partiallyObservable, int maxCycles,
+                int updateInterval, AI ai1, AI ai2) throws Exception {
+        this(utt, mapLocation, headless, partiallyObservable, maxCycles, updateInterval);
+
+        this.ai1 = ai1;
+        this.ai2 = ai2;
+    }
+
+    private Game(UnitTypeTable utt, String mapLocation, boolean headless, boolean partiallyObservable, int maxCycles,
+                 int updateInterval) throws Exception {
+
+        this.utt = utt;
+
+        PhysicalGameState pgs = PhysicalGameState.load(mapLocation, utt);
 
         gs = new GameState(pgs, utt);
-
-        partiallyObservable = gameSettings.isPartiallyObservable();
-        headless = gameSettings.isHeadless();
-        maxCycles = gameSettings.getMaxCycles();
-        updateInterval = gameSettings.getUpdateInterval();
-
-        Constructor cons1 = Class.forName(gameSettings.getAI1())
-            .getConstructor(UnitTypeTable.class);
-        ai1 = (AI) cons1.newInstance(utt);
-        Constructor cons2 = Class.forName(gameSettings.getAI2())
-            .getConstructor(UnitTypeTable.class);
-        ai2 = (AI) cons2.newInstance(utt);
+        this.partiallyObservable = partiallyObservable;
+        this.headless = headless;
+        this.maxCycles = maxCycles;
+        this.updateInterval = updateInterval;
     }
 
     /**


### PR DESCRIPTION
I have incorporated the remarks by @santiontanon in https://github.com/santiontanon/microrts/pull/71#issuecomment-560503951 and found a way for `Thread.sleep()` to be called in the main game loop only once and only if the AI agents have not taken more time than the specified interval to make their actions. Even then, `Thread.sleep()` only waits for the _remaining_ interval time, and not the _total_ interval time.