### PR TITLE
Fix microRTS opening FrontEnd after standalone game ends

### DIFF
--- a/src/rts/MicroRTS.java
+++ b/src/rts/MicroRTS.java
@@ -41,8 +41,10 @@ public class MicroRTS {
         switch (gameSettings.getLaunchMode()) {
             case STANDALONE:
                 runStandAloneGame(gameSettings);
+                break;
             case GUI:
                 FrontEnd.main(args);
+                break;
             case SERVER:
                 startServer(gameSettings);
                 break;


### PR DESCRIPTION
I have noticed that the class `MicroRTS.java` calls `FrontEnd.java` after running a standalone game. I realized this happens because there is no `break;` in a few `case` statements inside `MicroRTS.java`.

A few clues made me consider this as a bug:
- there seems to be no point in starting the GUI after a standalone game is executed, as the GUI does not display any information regarding the game
- the GUI is not started after a Remote game is executed
- this class was not made by me or by @santiontanon

So I fixed it.