### PR TITLE
Fix compilation for Java 8 and add Java 8 as compilation target in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: java
 jdk:
+  - oraclejdk8
   - oraclejdk9
   - oraclejdk11
   - oraclejdk12
+  - openjdk8
   - openjdk9
   - openjdk10
   - openjdk11

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: java
 jdk:
-  - oraclejdk8
   - oraclejdk9
   - oraclejdk11
   - oraclejdk12
@@ -11,4 +10,6 @@ jdk:
   - openjdk12
   - openjdk13
 
-script: javac -cp "lib/*" -d bin $(find . -name "*.java")
+script:
+  - mkdir bin
+  - javac -cp "lib/*" -d bin $(find . -name "*.java")

--- a/src/ai/ahtn/domain/MethodDecomposition.java
+++ b/src/ai/ahtn/domain/MethodDecomposition.java
@@ -545,7 +545,7 @@ public class MethodDecomposition {
         List<Pair<Integer,List<Term>>> l = new ArrayList<>();
         convertToOperatorList(l);
         // sort the list:
-        l.sort(new Comparator<>() {
+        l.sort(new Comparator<Pair<Integer, List<Term>>>() {
             public int compare(Pair<Integer, List<Term>> o1, Pair<Integer, List<Term>> o2) {
                 return Integer.compare(o1.m_a, o2.m_a);
             }

--- a/src/ai/machinelearning/bayes/ActionInterdependenceModel.java
+++ b/src/ai/machinelearning/bayes/ActionInterdependenceModel.java
@@ -206,7 +206,7 @@ public class ActionInterdependenceModel extends BayesianModel {
         }
         
         // sort features:
-        featureIndexes.sort(new Comparator<>() {
+        featureIndexes.sort(new Comparator<Integer>() {
             public int compare(Integer o1, Integer o2) {
                 return Double.compare(featureGR.get(o2), featureGR.get(o1));
             }

--- a/src/ai/machinelearning/bayes/CalibratedNaiveBayes.java
+++ b/src/ai/machinelearning/bayes/CalibratedNaiveBayes.java
@@ -154,7 +154,7 @@ public class CalibratedNaiveBayes extends BayesianModel {
         }
         
         // sort features:
-        featureIndexes.sort(new Comparator<>() {
+        featureIndexes.sort(new Comparator<Integer>() {
             public int compare(Integer o1, Integer o2) {
                 return Double.compare(featureGR.get(o2), featureGR.get(o1));
             }

--- a/src/ai/montecarlo/lsi/LSI.java
+++ b/src/ai/montecarlo/lsi/LSI.java
@@ -280,7 +280,7 @@ public class LSI extends AIWithComputationBudget {
                             case POST_ENTROPY_MAX:
                             case POST_MAX_DIFF:
                             case POST_MAX_TIME_NORMALIZE:
-                                evaluatedIndices.sort(new Comparator<>() {
+                                evaluatedIndices.sort(new Comparator<Pair<Integer, Double>>() {
 
                                     @Override
                                     public int compare(Pair<Integer, Double> p1, Pair<Integer, Double> p2) {
@@ -305,7 +305,7 @@ public class LSI extends AIWithComputationBudget {
 
                         // remove the single-actions of the weakest
                         evaluatedIndices = evaluatedIndices.subList(0, noToRemove);
-                        evaluatedIndices.sort(new Comparator<>() {
+                        evaluatedIndices.sort(new Comparator<Pair<Integer, Double>>() {
 
                             @Override
                             public int compare(Pair<Integer, Double> p1, Pair<Integer, Double> p2) {
@@ -691,7 +691,7 @@ public class LSI extends AIWithComputationBudget {
 
                 choseActList.add(new Pair<>(j, value));
             }
-            choseActList.sort(new Comparator<>() {
+            choseActList.sort(new Comparator<Pair<Integer, Double>>() {
 
                 @Override
                 public int compare(Pair<Integer, Double> p1, Pair<Integer, Double> p2) {
@@ -703,7 +703,7 @@ public class LSI extends AIWithComputationBudget {
             });
 
             choseActList = choseActList.subList(0, choseActList.size() - relaxationLimit);
-            choseActList.sort(new Comparator<>() {
+            choseActList.sort(new Comparator<Pair<Integer, Double>>() {
 
                 @Override
                 public int compare(Pair<Integer, Double> p1, Pair<Integer, Double> p2) {
@@ -835,7 +835,7 @@ public class LSI extends AIWithComputationBudget {
             // include elite combinations from estimation phase
             List<Entry<PlayerAction, Pair<Double, Integer>>> eliteEntries =
                     new ArrayList<>(elitePlayerActions.entrySet());
-            eliteEntries.sort(new Comparator<>() {
+            eliteEntries.sort(new Comparator<Entry<PlayerAction, Pair<Double, Integer>>>() {
 
                 @Override
                 public int compare(Entry<PlayerAction, Pair<Double, Integer>> e1,
@@ -912,7 +912,7 @@ public class LSI extends AIWithComputationBudget {
         }
 
         for (int i = 0; i <= budget - actionCount; i++) {
-            actionList.sort(new Comparator<>() {
+            actionList.sort(new Comparator<Pair<PlayerAction, Pair<Double, Integer>>>() {
 
                 @Override
                 public int compare(Pair<PlayerAction, Pair<Double, Integer>> p1, Pair<PlayerAction, Pair<Double, Integer>> p2) {

--- a/src/ai/montecarlo/lsi/LSI.java
+++ b/src/ai/montecarlo/lsi/LSI.java
@@ -290,7 +290,7 @@ public class LSI extends AIWithComputationBudget {
                                 });
                                 break;
                             case POST_ENTROPY_MIN:
-                                evaluatedIndices.sort(new Comparator<>() {
+                                evaluatedIndices.sort(new Comparator<Pair<Integer, Double>>() {
 
                                     @Override
                                     public int compare(Pair<Integer, Double> p1, Pair<Integer, Double> p2) {

--- a/src/ai/montecarlo/lsi/Sampling.java
+++ b/src/ai/montecarlo/lsi/Sampling.java
@@ -98,7 +98,7 @@ public class Sampling {
                 Collections.shuffle(ent_list);
                 break;
             case ENTROPY:
-                ent_list.sort(new Comparator<>() {
+                ent_list.sort(new Comparator<Pair<Integer, Double>>() {
                     @Override
                     public int compare(Pair<Integer, Double> p1, Pair<Integer, Double> p2) {
                         return p1.m_b.compareTo(p2.m_b);
@@ -318,7 +318,7 @@ public class Sampling {
             pair.m_b.m_b = oldNum + num;
         }
 
-        actionList.sort(new Comparator<>() {
+        actionList.sort(new Comparator<Pair<PlayerAction, Pair<Double, Integer>>>() {
 
             @Override
             public int compare(Pair<PlayerAction, Pair<Double, Integer>> p1, Pair<PlayerAction, Pair<Double, Integer>> p2) {
@@ -340,7 +340,7 @@ public class Sampling {
             pair.m_b = (pair.m_b*numEvalPrevious + eval*numEval)/(numEvalPrevious + numEval);
         }
 
-        actionList.sort(new Comparator<>() {
+        actionList.sort(new Comparator<Pair<PlayerAction, Double>>() {
 
             @Override
             public int compare(Pair<PlayerAction, Double> p1, Pair<PlayerAction, Double> p2) {
@@ -359,7 +359,7 @@ public class Sampling {
             pair.m_b = (pair.m_b*numEvalPrevious + eval*numEval)/(numEvalPrevious + numEval);
         }
 
-        actionList.sort(new Comparator<>() {
+        actionList.sort(new Comparator<Pair<PlayerAction, Double>>() {
 
             @Override
             public int compare(Pair<PlayerAction, Double> p1, Pair<PlayerAction, Double> p2) {

--- a/src/ai/scv/SCV.java
+++ b/src/ai/scv/SCV.java
@@ -230,7 +230,7 @@ public class SCV extends AIWithComputationBudget {
 
         PlayerAction resultado = new PlayerAction();
         ArrayList<UnitAction> vote = new ArrayList<>();
-        TreeMap<UnitAction, Integer> contagem = new TreeMap<>(new Comparator<>() {
+        TreeMap<UnitAction, Integer> contagem = new TreeMap<>(new Comparator<UnitAction>() {
             @Override
             public int compare(UnitAction u1, UnitAction u2) {
                 if (u1.equals(u2)) {

--- a/src/util/RunnableWithTimeOut.java
+++ b/src/util/RunnableWithTimeOut.java
@@ -22,7 +22,7 @@ import java.util.concurrent.TimeoutException;
 public class RunnableWithTimeOut {
 
     public static void runWithTimeout(final Runnable runnable, long timeout, TimeUnit timeUnit) throws Exception {
-        runWithTimeout(new Callable<>() {
+        runWithTimeout(new Callable<Object>() {
             public Object call() throws Exception {
                 runnable.run();
                 return null;


### PR DESCRIPTION
There was an additional instance of `<>` in anonymous classes.

Compilation is now successful on OpenJDK 8.